### PR TITLE
Adding missing optional dev dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ setup(
     ],
     extras_require={
         'dev': [
-            'profilehooks', 'psutil', 'click', 'pre-commit', 'yapf', 'prospector', 'pylint', 'pytest', 'pytest-cov',
-            'memory-profiler', 'pywin32; platform_system == "Windows"'
+            'click', 'coverage', 'memory-profiler', 'pre-commit', 'profilehooks', 'prospector', 'psutil', 'pylint',
+            'pytest', 'pytest-cov', 'pytest-benchmark', 'pywin32; platform_system == "Windows"', 'yapf'
         ],
     },
     packages=find_packages(),


### PR DESCRIPTION
They were listed in dev-requirements.txt with the correct version (and used by the tests) but they were missing in `setup.py`.
They were `pytest-benchmark` and `coverage`.
