### PR TITLE
✨ Add the concept of a (unique) container ID

### DIFF
--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -3033,3 +3033,14 @@ def test_pack_all_loose_many(temp_container):
     temp_container.pack_all_loose()
     retrieved = temp_container.get_objects_content(expected.keys())
     assert retrieved == expected
+
+
+def test_container_id(temp_container):
+    """Check the creation of unique container IDs."""
+    old_container_id = temp_container.container_id
+    assert old_container_id is not None
+    assert isinstance(old_container_id, str)
+
+    # Re-initialize: it should get a new container_id
+    temp_container.init_container(clear=True)
+    assert old_container_id != temp_container.container_id


### PR DESCRIPTION
This fixes #11
I also fixed a bug I discovered, where config values that
were cached but the cache was not cleared when re-initialising the
container.
To reduce the risk of such a problem, I am now only caching the *whole*
configuration dictionary (and not each value), and I don't need to
implement caching anymore for each single config value; and I just
need to clear one variable `self._config` rather than each newly-defined
configuration.

In addition, I add a test to check that re-initialising the container
creates a new container ID (`container.container_id`).