### PR TITLE
🐛 Fix performance regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
     - name: Create xml coverage
       run: coverage xml
     - name: Upload coverage to Codecov
+      # we pick th windows coverage to upload,
+      # since there are a number of tests run only on this platform
+      if: matrix.python-version == 3.7 && matrix.os == 'windows-latest'
       uses: codecov/codecov-action@v1
       with:
         file: ./coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,6 @@ jobs:
     - name: Create xml coverage
       run: coverage xml
     - name: Upload coverage to Codecov
-      # we pick th windows coverage to upload,
-      # since there are a number of tests run only on this platform
-      if: matrix.python-version == 3.7 && matrix.os == 'windows-latest'
       uses: codecov/codecov-action@v1
       with:
         file: ./coverage.xml

--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -370,9 +370,9 @@ class Container:  # pylint: disable=too-many-public-methods
 
     def _get_repository_config(self):
         """Return the repository config."""
-        if not self.is_initialised:
-            raise NotInitialised('The container is not initialised yet - use .init_container() first')
         if self._config is None:
+            if not self.is_initialised:
+                raise NotInitialised('The container is not initialised yet - use .init_container() first')
             with open(self._get_config_file()) as fhandle:
                 self._config = json.load(fhandle)
         return self._config


### PR DESCRIPTION
`Container.is_initialised` is a costly operation, loading the config JSON every time.
In https://github.com/aiidateam/disk-objectstore/commit/1d7c389c353185c1923c9addb1b107c283d5f561, the config is now called on every call to `loose_prefix_len`, leading to a massive performance degradation.

This PR makes sure the `is_initialised` test is called only if the config has not already been loaded into memory.

Before:

```
tests/test_benchmark.py::test_loose_read
ncalls  tottime percall cumtime percall filename:lineno(function)
1       0.0022  0.0022  0.3835  0.3835  disk-objectstore/disk_objectstore/container.py:824(get_objects_content)
1001    0.0055  0.0000  0.3758  0.0004  disk-objectstore/disk_objectstore/container.py:472(_get_objects_stream_meta_generator)
1000    0.0029  0.0000  0.3058  0.0003  disk-objectstore/disk_objectstore/container.py:213(_get_loose_path_from_hashkey)
3000    0.0019  0.0000  0.2959  0.0001  disk-objectstore/disk_objectstore/container.py:380(loose_prefix_len)
3000    0.0068  0.0000  0.2940  0.0001  disk-objectstore/disk_objectstore/container.py:371(_get_repository_config)
3000    0.0315  0.0000  0.2873  0.0001  disk-objectstore/disk_objectstore/container.py:270(is_initialised)
```

After:

```
tests/test_benchmark.py::test_loose_read
ncalls  tottime percall cumtime percall filename:lineno(function)
1       0.0014  0.0014  0.0793  0.0793  disk-objectstore/disk_objectstore/container.py:824(get_objects_content)
1001    0.0034  0.0000  0.0733  0.0001  disk-objectstore/disk_objectstore/container.py:472(_get_objects_stream_meta_generator)
1000    0.0240  0.0000  0.0240  0.0000  ~:0(<built-in method io.open>)
...
3000    0.0012  0.0000  0.0017  0.0000  disk-objectstore/disk_objectstore/container.py:380(loose_prefix_len)
```