### PR TITLE
Improve import time by moving `sqlalchemy` imports within function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ FNAME = os.path.join(FOLDER, MODULENAME, '__init__.py')
 with open(FNAME) as init:
     # Get lines that match, remove comment part
     # (assuming it's not in the string...)
-    VERSIONLINES = [l.partition('#')[0] for l in init.readlines() if l.startswith('__version__')]
+    VERSIONLINES = [line.partition('#')[0] for line in init.readlines() if line.startswith('__version__')]
 assert len(VERSIONLINES) == 1, 'Unable to detect the version lines'
 VERSIONLINE = VERSIONLINES[0]
 VERSION = VERSIONLINE.partition('=')[2].replace('"', '').replace("'", '').strip()
@@ -29,7 +29,7 @@ setup(
     author='Giovanni Pizzi',
     version=VERSION,
     install_requires=[
-        'sqlalchemy',
+        'sqlalchemy<1.4',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
This was discovered as a result of this library being used in
`aiida-core`, whose CLI command `verdi` increased in loading time
significantly once it started to import `disk_objectstore`.

Profiling pointed to `sqlalchemy` being the culprit. By moving the
imports from the module level to within the function scope, the loading
time is reduced from 0.11 seconds on average to about 0.03 seconds. This
reduction by 3 to 4 times is significant.