### PR TITLE
Lift partially limit on SQLAlchemy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     author='Giovanni Pizzi',
     version=VERSION,
     install_requires=[
-        'sqlalchemy<1.4',
+        'sqlalchemy<2',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Limit was on sqlalchemy<1.4.
I think this was because of python 3.5 support being dropped in SQLAlchemy 1.4.
Now that #106 is merged (py3.5 support dropped), I'm here moving the limit to <2, so we check this works.