### PR TITLE
🔧 MAINTAIN: Add typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,8 +67,9 @@ repos:
       - psutil==5.8.0
       - pytest==6.2.4
 
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: v0.910
-  #   hooks:
-  #   - id: mypy
-  #     additional_dependencies: []
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.910
+    hooks:
+    - id: mypy
+      additional_dependencies: [typing-extensions]
+      files: ^(disk_objectstore/.*py)$

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,3 +11,4 @@ include LICENSE.txt
 include CHANGELOG.md
 include README.md
 include requirements.lock
+include disk_objectstore/py.typed

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,3 +11,6 @@ coverage:
           target: auto
           threshold: 1%
           base: auto
+    patch:
+      default:
+        threshold: 1%

--- a/disk_objectstore/examples/example_objectstore.py
+++ b/disk_objectstore/examples/example_objectstore.py
@@ -143,9 +143,7 @@ def main(
         for filename, item in retrieved.items():
             assert (
                 item == files[filename]
-            ), "Mismatch (content) for {}, {} vs {}".format(
-                filename, item, files[filename]
-            )
+            ), f"Mismatch (content) for {filename}, {item!r} vs {files[filename]!r}"
 
         # Check that num_files new loose files are present now
         counts = container.count_objects()
@@ -299,7 +297,7 @@ def main(
     for filename, content in retrieved.items():
         assert (
             content == files[filename]
-        ), f"Mismatch (content) for {filename}, {content} vs {files[filename]}"
+        ), f"Mismatch (content) for {filename}, {content!r} vs {files[filename]!r}"
 
     print("All tests passed")
 

--- a/disk_objectstore/models.py
+++ b/disk_objectstore/models.py
@@ -5,7 +5,7 @@ from sqlalchemy.ext.declarative import declarative_base
 Base = declarative_base()  # pylint: disable=invalid-name,useless-suppression
 
 
-class Obj(Base):  # pylint: disable=too-few-public-methods
+class Obj(Base):  # type: ignore # pylint: disable=too-few-public-methods
     """The main (and only) table to store object metadata (hashkey, offset, length, ...)."""
 
     __tablename__ = "db_object"

--- a/disk_objectstore/py.typed
+++ b/disk_objectstore/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561

--- a/disk_objectstore/utils.py
+++ b/disk_objectstore/utils.py
@@ -10,17 +10,53 @@ import itertools
 import os
 import uuid
 import zlib
+from contextlib import contextmanager
 from enum import Enum
+from typing import (
+    Any,
+    BinaryIO,
+    Callable,
+    Iterable,
+    Iterator,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
+from zlib import error
+
+from sqlalchemy.engine.result import ResultProxy
+
+from .exceptions import ClosingNotAllowed, ModificationNotAllowed
+
+try:
+    from typing import Literal  # pylint: disable=ungrouped-imports
+except ImportError:
+    # Python <3.8 backport
+    from typing_extensions import Literal  # type: ignore
 
 try:
     import fcntl
 except ImportError:
     # Not available on Windows
-    fcntl = None
+    fcntl = None  # type: ignore[assignment]
 
-from contextlib import contextmanager
-
-from .exceptions import ClosingNotAllowed, ModificationNotAllowed
+# requires read method only
+StreamReadBytesType = Union[
+    BinaryIO,
+    "PackedObjectReader",
+    "CallbackStreamWrapper",
+    "ZlibLikeBaseStreamDecompresser",
+    "ZeroStream",
+]
+# requires read and seek capability
+StreamSeekBytesType = Union[
+    BinaryIO,
+    "PackedObjectReader",
+    "CallbackStreamWrapper",
+    "ZlibLikeBaseStreamDecompresser",
+]
+StreamWriteBytesType = BinaryIO
 
 # For now I I don't always activate it as I need to think at the right balance between
 # safety and performance/disk wearing
@@ -43,26 +79,25 @@ class LazyOpener:
     when opening the stream.
     """
 
-    def __init__(self, path, mode="rb"):
+    def __init__(self, path: str) -> None:
         """Lazily store file path and mode, but do not open now.
 
         File will be opened only when entering the context manager.
         """
         self._path = path
-        self._mode = mode
-        self._fhandle = None
+        self._fhandle: Optional[BinaryIO] = None
 
     @property
-    def path(self):
+    def path(self) -> str:
         """The file path."""
         return self._path
 
     @property
-    def mode(self):
+    def mode(self) -> Literal["rb"]:
         """The file open mode."""
-        return self._mode
+        return "rb"
 
-    def tell(self):
+    def tell(self) -> int:
         """Return the position in the underlying file object.
 
         :return: an integer with the position.
@@ -72,7 +107,7 @@ class LazyOpener:
             raise ValueError("I/O operation on closed file.")
         return self._fhandle.tell()
 
-    def __enter__(self):
+    def __enter__(self) -> BinaryIO:
         """Open the file when entering the with context manager.
 
         Note: you cannot open it twice with two with statements.
@@ -82,7 +117,7 @@ class LazyOpener:
         self._fhandle = open(self.path, mode=self.mode)
         return self._fhandle
 
-    def __exit__(self, exc_type, value, traceback):
+    def __exit__(self, exc_type, value, traceback) -> None:
         """Close the file when exiting the with context manager."""
         if self._fhandle is not None:
             if not self._fhandle.closed:
@@ -91,7 +126,7 @@ class LazyOpener:
 
 
 @contextmanager
-def nullcontext(enter_result):
+def nullcontext(enter_result: Any) -> Iterator[Any]:
     """Return a context manager that returns enter_result from __enter__, but otherwise does nothing.
 
     This can be replaced by ``contextlib.nullcontext`` if we want to support only py>=3.7.
@@ -104,13 +139,13 @@ class ObjectWriter:  # pylint: disable=too-many-instance-attributes
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        sandbox_folder,
-        loose_folder,
-        loose_prefix_len,
-        duplicates_folder,
-        hash_type,
-        trust_existing=False,
-    ):
+        sandbox_folder: str,
+        loose_folder: str,
+        loose_prefix_len: int,
+        duplicates_folder: str,
+        hash_type: str,
+        trust_existing: bool = False,
+    ) -> None:
         """Initialise an object to store a new loose object.
 
         :param sandbox_folder: the folder to store objects while still giving
@@ -130,23 +165,23 @@ class ObjectWriter:  # pylint: disable=too-many-instance-attributes
         self._loose_folder = loose_folder
         self._duplicates_folder = duplicates_folder
         self._hash_type = hash_type
-        self._hashkey = None
+        self._hashkey: Optional[str] = None
         self._loose_prefix_len = loose_prefix_len
         self._stored = False
-        self._obj_path = None
-        self._filehandle = None
+        self._obj_path: Optional[str] = None
+        self._filehandle: Optional[HashWriterWrapper] = None
         self._trust_existing = trust_existing
 
     @property
-    def hash_type(self):
+    def hash_type(self) -> str:
         """Return the currently used hash type."""
         return self._hash_type
 
-    def get_hashkey(self):
+    def get_hashkey(self) -> Optional[str]:
         """Return the object hash key. Return None if the stream wasn't opened yet."""
         return self._hashkey
 
-    def __enter__(self):
+    def __enter__(self) -> "HashWriterWrapper":
         """Start creating a new object in a context manager.
 
         You will get access access to a file-like object.
@@ -157,9 +192,7 @@ class ObjectWriter:  # pylint: disable=too-many-instance-attributes
             raise OSError("You have already opened this ObjectWriter instance")
         if self._stored:
             raise ModificationNotAllowed(
-                "You have already tried to store this object '{}'".format(
-                    self.get_hashkey()
-                )
+                f"You have already tried to store this object '{self.get_hashkey()}'"
             )
         # Create a new uniquely-named file in the sandbox.
         # It seems faster than using a NamedTemporaryFile, see benchmarks.
@@ -169,15 +202,16 @@ class ObjectWriter:  # pylint: disable=too-many-instance-attributes
         )
         return self._filehandle
 
-    def __exit__(
-        self, exc_type, value, traceback
-    ):  # pylint: disable=too-many-branches, too-many-statements
+    def __exit__(  # pylint: disable=too-many-branches, too-many-statements
+        self, exc_type: Any, value: Any, traceback: Any
+    ) -> None:
         """
         Close the file object, and move it from the sandbox to the loose
         object folder, possibly using sharding if loose_prexix_len is not 0.
         """
         try:
             if exc_type is None:
+                assert self._filehandle is not None and self._obj_path is not None
                 if self._filehandle.closed:
                     raise ClosingNotAllowed(
                         "You cannot close the file handle yourself!"
@@ -325,10 +359,10 @@ class ObjectWriter:  # pylint: disable=too-many-instance-attributes
 
             if self._filehandle is not None and not self._filehandle.closed:
                 self._filehandle.close()
-            if os.path.exists(self._obj_path):
+            if self._obj_path and os.path.exists(self._obj_path):
                 os.remove(self._obj_path)
 
-    def _store_duplicate_copy(self, source_file, hashkey):
+    def _store_duplicate_copy(self, source_file: str, hashkey: str) -> None:
         """This function is called (on Windows) when trying to store a file that already exists.
 
         In the `clean_storage` I will clean up old copies if the hash matches.
@@ -345,18 +379,39 @@ class PackedObjectReader:
     """A class to read from a pack file.
 
     This ensures that the .read() method works and does not go beyond the
-    length of the given object."""
+    length of the given object.
+    """
+
+    def __init__(self, fhandle: StreamSeekBytesType, offset: int, length: int) -> None:
+        """
+        Initialises the reader to a pack file.
+
+        :param fhandle: an open handle to the pack file, must be opened in read and binary mode.
+        :param offset: the integer offset where in the fhandle where the object starts.
+        :param length: the integer length of the byte stream.
+          The read() method will ensure that you never go beyond the given length.
+        """
+        assert "b" in fhandle.mode
+        assert "r" in fhandle.mode
+
+        self._fhandle = fhandle
+        self._offset = offset
+        self._length = length
+
+        # Move to the offset position, and keep track of the internal position
+        self._fhandle.seek(self._offset)
+        self._update_pos()
 
     @property
-    def mode(self):
+    def mode(self) -> str:
         return self._fhandle.mode
 
-    @property
-    def seekable(self):
+    @staticmethod
+    def seekable() -> bool:
         """Return whether object supports random access."""
         return True
 
-    def seek(self, target, whence=0):
+    def seek(self, target: int, whence: int = 0) -> int:
         """Change stream position.
 
         Note that contrary to a standard file, also seeking beyond the borders will raise a ValueError.
@@ -387,31 +442,11 @@ class PackedObjectReader:
         # seek returns the new absolute position
         return target
 
-    def tell(self):
+    def tell(self) -> int:
         """Return current stream position, relative to the internal offset."""
         return self._fhandle.tell() - self._offset
 
-    def __init__(self, fhandle, offset, length):
-        """
-        Initialises the reader to a pack file.
-
-        :param fhandle: an open handle to the pack file, must be opened in read and binary mode.
-        :param offset: the integer offset where in the fhandle where the object starts.
-        :param length: the integer length of the byte stream.
-          The read() method will ensure that you never go beyond the given length.
-        """
-        assert "b" in fhandle.mode
-        assert "r" in fhandle.mode
-
-        self._fhandle = fhandle
-        self._offset = offset
-        self._length = length
-
-        # Move to the offset position, and keep track of the internal position
-        self._fhandle.seek(self._offset)
-        self._update_pos()
-
-    def _update_pos(self):
+    def _update_pos(self) -> None:
         """Update the internal position variable with the correct value.
 
         This function must be called (internally) after any operation that
@@ -426,7 +461,7 @@ class PackedObjectReader:
             "PackedObjectReader didn't manage to prevent to go beyond the length (in the negative direction)!"
         )
 
-    def read(self, size=-1):
+    def read(self, size: int = -1) -> bytes:
         """
         Read and return up to n bytes.
 
@@ -451,6 +486,13 @@ class PackedObjectReader:
         self._update_pos()
         return stream
 
+    def __enter__(self) -> "PackedObjectReader":
+        """Use as context manager."""
+        return self
+
+    def __exit__(self, exc_type, value, traceback) -> None:
+        """Close context manager."""
+
 
 class CallbackStreamWrapper:
     """A class to just wrap a read stream, but perform a callback every few bytes.
@@ -458,20 +500,49 @@ class CallbackStreamWrapper:
     Should be used only for streams open in read mode.
     """
 
+    def __init__(
+        self,
+        stream: StreamSeekBytesType,
+        callback: Optional[Callable],
+        total_length: int = 0,
+        description: str = "Streamed object",
+    ) -> None:
+        """
+        Initialises the reader to a given stream.
+
+        :param stream: an open stream
+        :param callback: a callback to call to update the status (or None if not needed)
+        :param total_length: the expected length
+        """
+        self._stream = stream
+        self._callback = callback
+        self._total_length = total_length
+        self._description = description
+
+        # Update at most 400 times, avoiding to increase CPU usage; if the list is small: every object.
+        self._update_every: int = max(int(total_length / 400), 1) if total_length else 1
+        # Counter of how many objects have been since since the last update.
+        # A new callback will be performed when this value is > update_every.
+        self._since_last_update: int = 0
+        if self._callback:
+            # If we have a callback, compute the total count of objects in this pack
+            self._callback(
+                action="init", value={"total": total_length, "description": description}
+            )
+
     @property
-    def mode(self):
+    def mode(self) -> str:
         return self._stream.mode
 
-    @property
-    def seekable(self):
+    def seekable(self) -> bool:
         """Return whether object supports random access."""
-        return self._stream.seekable
+        return self._stream.seekable()
 
-    def seek(self, target, whence=0):
+    def seek(self, target: int, whence: int = 0) -> int:
         """Change stream position."""
         if target > self.tell():
             if self._callback:
-                self._since_last_update += target - self.tell()
+                self._since_last_update = self._since_last_update + target - self.tell()
                 if self._since_last_update >= self._update_every:
                     self._callback(action="update", value=self._since_last_update)
                     self._since_last_update = 0
@@ -493,35 +564,11 @@ class CallbackStreamWrapper:
 
         return self._stream.seek(target, whence)
 
-    def tell(self):
+    def tell(self) -> int:
         """Return current stream position."""
         return self._stream.tell()
 
-    def __init__(self, stream, callback, total_length=0, description="Streamed object"):
-        """
-        Initialises the reader to a given stream.
-
-        :param stream: an open stream
-        :param callback: a callback to call to update the status (or None if not needed)
-        :param total_length: the expected length
-        """
-        self._stream = stream
-        self._callback = callback
-        self._total_length = total_length
-        self._description = description
-
-        if self._callback:
-            # If we have a callback, compute the total count of objects in this pack
-            self._callback(
-                action="init", value={"total": total_length, "description": description}
-            )
-            # Update at most 400 times, avoiding to increase CPU usage; if the list is small: every object.
-            self._update_every = max(int(total_length / 400), 1) if total_length else 1
-            # Counter of how many objects have been since since the last update.
-            # A new callback will be performed when this value is > update_every.
-            self._since_last_update = 0
-
-    def read(self, size=-1):
+    def read(self, size: int = -1) -> bytes:
         """
         Read and return up to n bytes.
 
@@ -541,7 +588,14 @@ class CallbackStreamWrapper:
 
         return data
 
-    def close_callback(self):
+    def __enter__(self) -> "CallbackStreamWrapper":
+        """Use as context manager."""
+        return self
+
+    def __exit__(self, exc_type, value, traceback) -> None:
+        """Close context manager."""
+
+    def close_callback(self) -> None:
         """
         Call the wrap up closing calls for the callback.
 
@@ -555,7 +609,9 @@ class CallbackStreamWrapper:
             self._callback(action="close", value=None)
 
 
-def rename_callback(callback, new_description):
+def rename_callback(
+    callback: Optional[Callable], new_description: str
+) -> Optional[Callable]:
     """Given a callback, return a new one where the description will be changed to `new_name`.
 
     Works even if `callback` is None (in this case, it returns None).
@@ -571,8 +627,8 @@ def rename_callback(callback, new_description):
         if action == "init":
             new_value = value.copy()
             new_value["description"] = new_description
-            return callback(action, new_value)
-        return callback(action, value)
+            return callback(action, new_value)  # type: ignore
+        return callback(action, value)  # type: ignore
 
     return wrapper_callback
 
@@ -587,23 +643,7 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
 
     _CHUNKSIZE = 524288
 
-    @property
-    @abc.abstractmethod
-    def decompressobj_class(self):
-        """Return here the `decompressobj` class of the given compression type.
-
-        Needs to be implemented by subclasses.
-        """
-
-    @property
-    @abc.abstractmethod
-    def decompress_error(self):
-        """Return here the Exception (or tuple of exceptions) that need to be caught if there is a compression error.
-
-        Needs to be implemented by subclasses.
-        """
-
-    def __init__(self, compressed_stream):
+    def __init__(self, compressed_stream: StreamSeekBytesType) -> None:
         """Create the class from a given compressed bytestream.
 
         :param compressed_stream: an open bytes stream that supports the .read() method,
@@ -614,7 +654,11 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
         self._internal_buffer = b""
         self._pos = 0
 
-    def read(self, size=-1):
+    @property
+    def mode(self) -> str:
+        return getattr(self._compressed_stream, "mode", "rb")
+
+    def read(self, size: int = -1) -> bytes:
         """
         Read and return up to n bytes.
 
@@ -680,16 +724,39 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
 
         return to_return
 
+    def __enter__(self) -> "ZlibLikeBaseStreamDecompresser":
+        """Use as context manager."""
+        return self
+
+    def __exit__(self, exc_type, value, traceback) -> None:
+        """Close context manager."""
+
     @property
-    def seekable(self):
+    @abc.abstractmethod
+    def decompressobj_class(self):
+        """Return here the `decompressobj` class of the given compression type.
+
+        Needs to be implemented by subclasses.
+        """
+
+    @property
+    @abc.abstractmethod
+    def decompress_error(self):
+        """Return here the Exception (or tuple of exceptions) that need to be caught if there is a compression error.
+
+        Needs to be implemented by subclasses.
+        """
+
+    @staticmethod
+    def seekable() -> bool:
         """Return whether object supports random access."""
         return True
 
-    def tell(self):
+    def tell(self) -> int:
         """Return current position in file."""
         return self._pos
 
-    def seek(self, target, whence=0):
+    def seek(self, target: int, whence: int = 0) -> int:
         """Change stream position.
 
         ..note:: This is particularly inefficient if `target > 0` since it will have
@@ -737,17 +804,17 @@ class ZlibStreamDecompresser(ZlibLikeBaseStreamDecompresser):
     uncompressed bytes when being read via the .read() method."""
 
     @property
-    def decompressobj_class(self):
+    def decompressobj_class(self) -> Callable:
         """Return the `decompressobj` class of zlib."""
         return zlib.decompressobj
 
     @property
-    def decompress_error(self):
+    def decompress_error(self) -> Type[error]:
         """Return the zlib error raised when there is an error."""
         return zlib.error
 
 
-def _get_compression_algorithm_info(algorithm):
+def _get_compression_algorithm_info(algorithm: str):
     """Return a compresser and a decompresser for the given algorithm."""
     known_algorithms = {
         "zlib": {
@@ -768,9 +835,9 @@ def _get_compression_algorithm_info(algorithm):
         )
     try:
         kwargs = {
-            algorithm_info["variant_name"]: algorithm_info["variant_mapper"][variant]
+            algorithm_info["variant_name"]: algorithm_info["variant_mapper"][variant]  # type: ignore
         }
-        compresser = algorithm_info["compressobj"](**kwargs)
+        compresser = algorithm_info["compressobj"](**kwargs)  # type: ignore
     except KeyError:
         # pylint: disable=raise-missing-from
         raise ValueError(
@@ -782,7 +849,7 @@ def _get_compression_algorithm_info(algorithm):
     return compresser, decompresser
 
 
-def get_compressobj_instance(algorithm):
+def get_compressobj_instance(algorithm: str):
     """Return a compressobj class with a given algorithm.
 
     :param algorithm: A string defining the algorithm and its variant.
@@ -793,7 +860,7 @@ def get_compressobj_instance(algorithm):
     return _get_compression_algorithm_info(algorithm)[0]
 
 
-def get_stream_decompresser(algorithm):
+def get_stream_decompresser(algorithm: str) -> Type[ZlibStreamDecompresser]:
     """Return a StreamDecompresser class with a given algorithm.
 
     :param algorithm: a compression algorithm (see `get_compressionobj_instance` for a description).
@@ -804,7 +871,7 @@ def get_stream_decompresser(algorithm):
 class ZeroStream:
     """A class to return an (unseekable) stream returning only zeros, with length length."""
 
-    def __init__(self, length):
+    def __init__(self, length: int) -> None:
         """
         Initialises the object and specifies the expected length.
 
@@ -814,7 +881,11 @@ class ZeroStream:
         self._length = length
         self._pos = 0
 
-    def read(self, size=-1):
+    @property
+    def mode(self) -> str:
+        return "rb"
+
+    def read(self, size: int = -1) -> bytes:
         """
         Read and return up to n bytes (composed only of zeros).
 
@@ -840,7 +911,7 @@ class ZeroStream:
         return stream
 
 
-def is_known_hash(hash_type):
+def is_known_hash(hash_type: str) -> bool:
     """Return True if the hash_type is known, False otherwise."""
     try:
         get_hash(hash_type)
@@ -849,7 +920,7 @@ def is_known_hash(hash_type):
         return False
 
 
-def get_hash(hash_type):
+def get_hash(hash_type: str) -> Callable:
     """Return a hash class with an update method and a hexdigest method."""
     known_hashes = {"sha1": hashlib.sha1, "sha256": hashlib.sha256}
 
@@ -860,7 +931,7 @@ def get_hash(hash_type):
         raise ValueError(f"Unknown or unsupported hash type '{hash_type}'")
 
 
-def _compute_hash_for_filename(filename, hash_type):
+def _compute_hash_for_filename(filename: str, hash_type: str) -> Optional[str]:
     """Return the hash for the given file.
 
     Will read the file in chunks.
@@ -890,7 +961,7 @@ def _compute_hash_for_filename(filename, hash_type):
 class HashWriterWrapper:
     """A class that gets a stream open in write mode and wraps it in a new class that computes a hash while writing."""
 
-    def __init__(self, write_stream, hash_type):
+    def __init__(self, write_stream: BinaryIO, hash_type: str) -> None:
         """Create the class from a given compressed bytestream.
 
         :param write_stream: an open bytes stream that supports the .write() method.
@@ -906,15 +977,15 @@ class HashWriterWrapper:
         self._position = self._write_stream.tell()
 
     @property
-    def hash_type(self):
+    def hash_type(self) -> str:
         """Return the currently used hash type."""
         return self._hash_type
 
-    def flush(self):
+    def flush(self) -> None:
         """Flush the internal I/O buffer."""
         self._write_stream.flush()
 
-    def write(self, data):
+    def write(self, data: bytes) -> int:
         """
         Write binary data to the underlying write_stream object, and compute a hash at the same time.
         """
@@ -938,26 +1009,27 @@ class HashWriterWrapper:
 
         # Update the hash information
         self._hash.update(data)
+        return self._position
 
-    def hexdigest(self):
+    def hexdigest(self) -> str:
         """Return the hexdigest of the hash computed until now."""
         return self._hash.hexdigest()
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         """Return True if the underlying file is closed."""
         return self._write_stream.closed
 
-    def close(self):
+    def close(self) -> None:
         """Close the underlying file."""
         self._write_stream.close()
 
     @property
-    def mode(self):
+    def mode(self) -> str:
         """Return a string with the mode the file was open with."""
         return self._write_stream.mode
 
-    def fileno(self):
+    def fileno(self) -> int:
         """Return the integer file descriptor of the underlying file object."""
         return self._write_stream.fileno()
 
@@ -977,7 +1049,11 @@ def chunk_iterator(iterator, size):
     return iter(lambda: tuple(itertools.islice(iterator, size)), ())
 
 
-def safe_flush_to_disk(fhandle, real_path, use_fullsync=False):
+def safe_flush_to_disk(
+    fhandle: Union[StreamWriteBytesType, HashWriterWrapper],
+    real_path: str,
+    use_fullsync: bool = False,
+) -> None:
     """Tries to to its best to safely commit to disk.
 
     Note that calling this is needed to reduce the risk of data loss due to, e.g., a power failure.
@@ -995,7 +1071,9 @@ def safe_flush_to_disk(fhandle, real_path, use_fullsync=False):
     fhandle.flush()
 
     # Default fsync function, replaced on Mac OS X
-    _fsync_function = lambda fileno: os.fsync(  # pylint: disable=unnecessary-lambda
+    _fsync_function: Callable[
+        [Any], Any
+    ] = lambda fileno: os.fsync(  # pylint: disable=unnecessary-lambda
         fileno
     )
 
@@ -1028,7 +1106,10 @@ def safe_flush_to_disk(fhandle, real_path, use_fullsync=False):
         os.close(dirfd)
 
 
-def compute_hash_and_size(stream, hash_type):
+def compute_hash_and_size(
+    stream: StreamReadBytesType,
+    hash_type: str,
+) -> Tuple[str, int]:
     """Given a stream and a hash type, return the hash key (hexdigest) and the total size.
 
     :param stream: an open stream
@@ -1051,9 +1132,11 @@ def compute_hash_and_size(stream, hash_type):
     return hasher.hexdigest(), size
 
 
-def detect_where_sorted(
-    left_iterator, right_iterator, left_key=None
-):  # pylint: disable=too-many-branches, too-many-statements
+def detect_where_sorted(  # pylint: disable=too-many-branches, too-many-statements
+    left_iterator: Iterable[Any],
+    right_iterator: Iterable[Any],
+    left_key: Optional[Callable] = None,
+) -> Iterator[Tuple[Any, Location]]:
     """Generator that loops in alternation (but only once each) the two iterators and yields an element, specifying if
     it's only on the left, only on the right, or in both.
 
@@ -1182,13 +1265,13 @@ def detect_where_sorted(
         now_left = new_now_left
 
 
-def yield_first_element(iterator):
+def yield_first_element(iterator: Union[ResultProxy, zip]) -> Iterator[Union[str, int]]:
     """Given an iterator that returns a tuple, return an iterator that yields only the first element of the tuple."""
     for elem in iterator:
         yield elem[0]
 
 
-def merge_sorted(iterator1, iterator2):
+def merge_sorted(iterator1: Iterable[Any], iterator2: Iterable[Any]) -> Iterator[Any]:
     """Given two sorted iterators, return another sorted iterator being the union of the two."""
     for item, _ in detect_where_sorted(iterator1, iterator2):
         # Whereever it is (only left, only right, on both) I return the object.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,10 @@ docstring-min-length = 5
 
 [tool.pylint.design]
 max-locals = 20
+
+[tool.mypy]
+show_error_codes = true
+check_untyped_defs = true
+scripts_are_modules = true
+warn_unused_ignores = true
+warn_redundant_casts = true

--- a/requirements.lock
+++ b/requirements.lock
@@ -75,8 +75,10 @@ toml==0.10.2
     #   pre-commit
     #   pytest
     #   pytest-cov
-typing-extensions==3.10.0.0
-    # via importlib-metadata
+typing-extensions==3.10.0.0 ; python_version < "3.8"
+    # via
+    #   disk-objectstore (setup.py)
+    #   importlib-metadata
 virtualenv==20.7.2
     # via pre-commit
 zipp==3.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ keywords = object store, repository, file store
 packages = find:
 install_requires =
     sqlalchemy<1.4
+    typing-extensions;python_version < '3.8'
 python_requires = ~=3.7
 include_package_data = True
 

--- a/tests/concurrent_tests/periodic_worker.py
+++ b/tests/concurrent_tests/periodic_worker.py
@@ -189,7 +189,11 @@ def main(
             with container.get_objects_stream_and_meta(
                 all_hashkeys, skip_if_missing=False
             ) as triplets:
-                for obj_hashkey, stream, meta in triplets:
+                for (
+                    obj_hashkey,
+                    stream,
+                    meta,
+                ) in triplets:  # pylint: disable=not-an-iterable
                     if stream is None:
                         retrieved_content[obj_hashkey] = None
                     else:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -413,8 +413,8 @@ def test_directly_to_pack_streamed(
                 file_path = os.path.join(temp_dir2, key)
                 with open(file_path, "bw") as fhandle:
                     fhandle.write(content)
-                streams.append(utils.LazyOpener(file_path, mode="rb"))
-                streams_copy.append(utils.LazyOpener(file_path, mode="rb"))
+                streams.append(utils.LazyOpener(file_path))
+                streams_copy.append(utils.LazyOpener(file_path))
             obj_hashkeys = temp_container.add_streamed_objects_to_pack(
                 streams, compress=use_compression, open_streams=True
             )
@@ -3165,7 +3165,7 @@ def test_packs_read_in_order(temp_dir):
     with temp_container.get_objects_stream_and_meta(
         hashkeys, skip_if_missing=False
     ) as triplets:
-        for _, _, meta in triplets:
+        for _, _, meta in triplets:  # pylint: disable=not-an-iterable
             assert meta["type"] == ObjectType.PACKED
             if last_pack is None:
                 last_pack = meta["pack_id"]


### PR DESCRIPTION
~currently based on top of #112~

- Remove `@property` from `seekable` method (as per BinaryIO)
- Disallow mode in `LazyOpen` (should always be readable binary)
- ~add `__enter__`/`__exit__` methods to `PackedObjectReader`, `CallbackStreamWrapper`, `ZlibLikeBaseStreamDecompresser`, so they won't fail in `add_streamed_objects_to_pack` with `open_streams=True`~

Come across this issue for `get_objects`/`get_object_stream_and_meta`: https://github.com/PyCQA/pylint/issues/3233

Types initially generated with https://github.com/Instagram/MonkeyType
