### PR TITLE
Proof-of-concept implemenation for supporting multiple pack repositories

### DIFF
--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -251,7 +251,7 @@ class Container:  # pylint: disable=too-many-public-methods
             pack_id, allow_repack_pack=False
         ), f"Invalid pack ID {pack_id}"
         assert (
-            allow_repack_pack is True
+            allow_repack_pack is False
         ), "Please use _get_repack_path_from_pack_id to get a repack path valid for a pack_id"
 
         # Not in the main repository folder - try to locate it from the additional storages

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -3357,8 +3357,8 @@ def test_additional_pack_repo(temp_container):
         os.path.join(temp_container._get_pack_folder(), "0"),
         os.path.join(temp_dir, "packs"),
     )
-    new_pack = pathlib.Path(temp_container._get_pack_path_from_pack_id(0))
-    assert new_pack.relative_to(temp_dir)
+    new_pack = pathlib.Path(temp_container._get_pack_path_from_pack_id(0)).resolve()
+    assert new_pack.relative_to(pathlib.Path(temp_dir).resolve())
 
     # Now the pack to write to is pack 1
     assert temp_container._get_pack_id_to_write_to() == 1


### PR DESCRIPTION
This PR allows the packs to be stored in additional locations (*pack repositories*) other than the main object store folder.

The main reason for allowing this is allow *packs* to be moved to different file systems (slow but spacious ones) to free up spaces in the main filesystem (usually on a SSD), in case of growing demand of storage space. 

Packing loose objects and writing directly to the packs will only take place on the main storage to avoid any performance impact.

One exception is when repacking - this will be done directly inside the *pack repository* (on the same filesytem as the pack file to be repacked). This means there is no longer a single path for temporaray pack that is used for repacking (previously pack_id=-1), as its path  on the file system now depends on the id of the pack that is being repacked. 

The user is resposible for moving the packs, ideally when the repository is fully "offline". Online operation is still possible, but requires a sequence of copy-rename-unlink operations. 

Todos:

- [ ] allow getting sizes of each *pack repositories*
- [ ] More comprehensive tests
   - [ ] Test for repacking
   - [ ] Test for online concurrent pack relocation 
- [ ] CLI for displaying information of *pack repositories*
- [ ] CLI for moving packs while the repository is "online" (being accessed)
- [ ] CLI for checking the integrity, e.g. wheter there are "missing" packs. 


