### PR TITLE
allow sealling pack files which turn them into ZIP archives

### DIFF
--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -136,6 +136,9 @@ class Container:  # pylint: disable=too-many-public-methods
     # (after VACUUMing, as mentioned above).
     _MAX_CHUNK_ITERATE_LENGTH = 9500
 
+    # Size of the ZIP local file header
+    _ZIP_HEADER_SIZE = 30 + FN_SIZE + 20
+
     def __init__(self, folder: Union[str, Path]) -> None:
         """Create the class that represents the container.
 
@@ -358,11 +361,6 @@ class Container:  # pylint: disable=too-many-public-methods
         hasher = get_hash(hash_type)()
         hasher.update(b"")
         self._hash_place_holder = hasher.hexdigest()[:FN_SIZE]
-
-        # Size of the ZIP local file header
-        self._zip_header_size = 30 + len(self._hash_place_holder) + 20
-        # Size of the Data descriptor
-        self._zip_dd_size = 24  # struct.calcsize("<LLQQ")
 
         if clear:
             if os.path.exists(self._folder):
@@ -2413,7 +2411,7 @@ class Container:  # pylint: disable=too-many-public-methods
                 # Check that there are no overlapping objects
 
                 if (
-                    zip_compatible and (offset < current_pos + self._zip_header_size)
+                    zip_compatible and (offset < current_pos + self._ZIP_HEADER_SIZE)
                 ) or (not zip_compatible and (offset < current_pos)):
                     overlapping.append(hashkey)
 
@@ -2783,7 +2781,7 @@ class Container:  # pylint: disable=too-many-public-methods
         # Gather information for each object
         session = self._get_cached_session()
         all_zipinfo = []
-        header_size = self._zip_header_size
+        header_size = self._ZIP_HEADER_SIZE
         # Size of the file local header
         # the extra field takes 20 bytes with format "<HHQQ"
         stmt = (

--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -2758,7 +2758,8 @@ class Container:  # pylint: disable=too-many-public-methods
             )
 
         with open(
-            self._get_pack_path_from_pack_id(pack_id, allow_repack_pack=False)
+            self._get_pack_path_from_pack_id(pack_id, allow_repack_pack=False),
+            mode="rb",
         ) as pack_handle:
             if is_zip(pack_handle):
                 raise ValueError(f"Pack file {pack_id} has been sealed already!")

--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -2813,3 +2813,7 @@ class Container:  # pylint: disable=too-many-public-methods
         with self.lock_pack(str(pack_id), allow_repack_pack=False) as write_pack_handle:
 
             write_end_record(write_pack_handle, all_zipinfo)
+
+    def _is_pack_sealed(self, pack_id):
+        """Check if a pack is sealed"""
+        pack_loc = self._get_pack_path_from_pack_id(str(pack_id))

--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -1175,6 +1175,10 @@ class Container:  # pylint: disable=too-many-public-methods
         """
         assert self._is_valid_pack_id(pack_id, allow_repack_pack=allow_repack_pack)
 
+        # For sealed pack, we only allow reading
+        if pack_id in self.get_sealed_packs():
+            assert mode.startswith("r") and "+" not in mode
+
         # Open file in exclusive mode
         lock_file = os.path.join(self._get_pack_folder(), f"{pack_id}.lock")
         pack_file = self._get_pack_path_from_pack_id(
@@ -2823,11 +2827,8 @@ class Container:  # pylint: disable=too-many-public-methods
                 # Check the magic
                 if local_header[0] != zipfile.stringFileHeader:
                     raise ValueError(f"Cannot find ZIP header for record {zipinfo}")
-                # Read the filename
-                fname = write_pack_handle.read(fnlen).decode("ascii")
 
-                # Seek back and rewrite the file name
-                write_pack_handle.seek(-fnlen, 1)
+                # rewrite the file name
                 write_pack_handle.write(zipinfo.filename.encode("ascii"))
 
                 # Update the CRC field

--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -2756,11 +2756,12 @@ class Container:  # pylint: disable=too-many-public-methods
             raise ValueError(
                 f"Pack file {pack_id} is not written in ZIP compatible format and cannot be sealed."
             )
-        with self.lock_pack(
-            str(pack_id), allow_repack_pack=False, mode="rb"
+
+        with open(
+            self._get_pack_path_from_pack_id(pack_id, allow_repack_pack=False)
         ) as pack_handle:
             if is_zip(pack_handle):
-                raise ValueError(f"Pack file {pack_id} has already been sealed!")
+                raise ValueError(f"Pack file {pack_id} has been sealed already!")
 
         # Valid the pack conetents
         errors_and_crc = self._validate_hashkeys_pack(pack_id, include_crc=True)

--- a/disk_objectstore/database.py
+++ b/disk_objectstore/database.py
@@ -1,4 +1,5 @@
 """Models for the container index file (SQLite DB)."""
+import enum
 import os
 from enum import unique
 from typing import Optional
@@ -9,6 +10,14 @@ from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import text
 
 Base = declarative_base()  # pylint: disable=invalid-name,useless-suppression
+
+
+class PackState(enum.Enum):
+    """Enum for valid sate of seal packs"""
+
+    Sealed = "Sealed"
+    Archived = "Archived"
+    Unsealed = "Unsealed"
 
 
 class Obj(Base):  # pylint: disable=too-few-public-methods

--- a/disk_objectstore/database.py
+++ b/disk_objectstore/database.py
@@ -1,5 +1,6 @@
 """Models for the container index file (SQLite DB)."""
 import os
+from enum import unique
 from typing import Optional
 
 from sqlalchemy import Boolean, Column, Integer, String, create_engine, event
@@ -29,6 +30,17 @@ class Obj(Base):  # pylint: disable=too-few-public-methods
     pack_id = Column(
         Integer, nullable=False
     )  # integer ID of the pack in which this entry is stored
+
+
+class Pack(Base):  # pylint: disable=too-few-public-methods
+    """The table for storing the state of pack files. If missing, it means that the pack is currently active"""
+
+    __tablename__ = "db_pack"
+
+    id = Column(Integer, primary_key=True)
+    state = Column(String, nullable=False, unique=False)
+    md5 = Column(String, unique=True, nullable=False)
+    location = Column(String, nullable=True)
 
 
 def get_session(

--- a/disk_objectstore/database.py
+++ b/disk_objectstore/database.py
@@ -29,6 +29,11 @@ class Obj(Base):  # pylint: disable=too-few-public-methods
     pack_id = Column(
         Integer, nullable=False
     )  # integer ID of the pack in which this entry is stored
+    # CRC of the object - used for sealing the pack and making it ZIP compatible
+    crc = Column(
+        Integer,
+        nullable=True,
+    )
 
 
 def get_session(

--- a/disk_objectstore/database.py
+++ b/disk_objectstore/database.py
@@ -1,7 +1,6 @@
 """Models for the container index file (SQLite DB)."""
 import enum
 import os
-from enum import unique
 from typing import Optional
 
 from sqlalchemy import Boolean, Column, Integer, String, create_engine, event
@@ -15,9 +14,9 @@ Base = declarative_base()  # pylint: disable=invalid-name,useless-suppression
 class PackState(enum.Enum):
     """Enum for valid sate of seal packs"""
 
-    Sealed = "Sealed"
-    Archived = "Archived"
-    Unsealed = "Unsealed"
+    SEALED = "Sealed"
+    ARCHIVED = "Archived"
+    UNSEALED = "Unsealed"
 
 
 class Obj(Base):  # pylint: disable=too-few-public-methods

--- a/disk_objectstore/database.py
+++ b/disk_objectstore/database.py
@@ -29,11 +29,6 @@ class Obj(Base):  # pylint: disable=too-few-public-methods
     pack_id = Column(
         Integer, nullable=False
     )  # integer ID of the pack in which this entry is stored
-    # CRC of the object - used for sealing the pack and making it ZIP compatible
-    crc = Column(
-        Integer,
-        nullable=True,
-    )
 
 
 def get_session(

--- a/disk_objectstore/zipsupport.py
+++ b/disk_objectstore/zipsupport.py
@@ -1,0 +1,210 @@
+import struct
+import sys
+import zipfile
+from zipfile import (
+    ZIP64_LIMIT,
+    ZIP64_VERSION,
+    ZIP_DEFLATED,
+    ZIP_FILECOUNT_LIMIT,
+    ZIP_STORED,
+    ZipInfo,
+)
+
+_DD_SIGNATURE = 0x08074B50
+_EXTRA_FIELD_STRUCT = struct.Struct("<HH")
+
+
+def write_zip_header(fhandle, fname, compress_type=None):
+    """Write a zip header to the handle"""
+    zinfo = ZipInfo(fname)
+    zinfo.flag_bits = 0x08
+    compress_type_map = {"zlib": ZIP_DEFLATED, None: ZIP_STORED}
+    zinfo.compress_type = compress_type_map[compress_type]
+    header = zinfo.FileHeader(zip64=True)
+    fhandle.write(header)
+
+
+def write_file_describer(fhandle, crc, compressed_size, file_size):
+    """Write the tailing descriptor"""
+    fmt = "<LLQQ"  # ZIP64
+    fhandle.write(struct.pack(fmt, _DD_SIGNATURE, crc, compressed_size, file_size))
+
+
+def write_end_record(fhandle, zinfos):
+    """
+    Write the tailing central directory of contents and the end of zip-archive record
+    """
+    start_dir = fhandle.tell()
+    COMMENT = "ZIP-compatible pack file by disk-objectstore"
+    for zinfo in zinfos:  # write central directory
+        dt = zinfo.date_time
+        dosdate = (dt[0] - 1980) << 9 | dt[1] << 5 | dt[2]
+        dostime = dt[3] << 11 | dt[4] << 5 | (dt[5] // 2)
+        extra = []
+        if zinfo.file_size > ZIP64_LIMIT or zinfo.compress_size > ZIP64_LIMIT:
+            extra.append(zinfo.file_size)
+            extra.append(zinfo.compress_size)
+            file_size = 0xFFFFFFFF
+            compress_size = 0xFFFFFFFF
+        else:
+            file_size = zinfo.file_size
+            compress_size = zinfo.compress_size
+
+        if zinfo.header_offset > ZIP64_LIMIT:
+            extra.append(zinfo.header_offset)
+            header_offset = 0xFFFFFFFF
+        else:
+            header_offset = zinfo.header_offset
+
+        extra_data = zinfo.extra
+        min_version = 0
+        if extra:
+            # Append a ZIP64 field to the extra's
+            extra_data = _strip_extra(extra_data, (1,))
+            extra_data = (
+                struct.pack("<HH" + "Q" * len(extra), 1, 8 * len(extra), *extra)
+                + extra_data
+            )
+
+            min_version = ZIP64_VERSION
+
+        # if zinfo.compress_type == ZIP_BZIP2:
+        #     min_version = max(BZIP2_VERSION, min_version)
+        # elif zinfo.compress_type == ZIP_LZMA:
+        #     min_version = max(LZMA_VERSION, min_version)
+
+        extract_version = max(min_version, zinfo.extract_version)
+        create_version = max(min_version, zinfo.create_version)
+        try:
+            filename, flag_bits = zinfo._encodeFilenameFlags()
+            centdir = struct.pack(
+                zipfile.structCentralDir,
+                zipfile.stringCentralDir,
+                create_version,
+                zinfo.create_system,
+                extract_version,
+                zinfo.reserved,
+                flag_bits,
+                zinfo.compress_type,
+                dostime,
+                dosdate,
+                zinfo.CRC,
+                compress_size,
+                file_size,
+                len(filename),
+                len(extra_data),
+                len(zinfo.comment),
+                0,
+                zinfo.internal_attr,
+                zinfo.external_attr,
+                header_offset,
+            )
+        except DeprecationWarning:
+            print(
+                (
+                    zipfile.structCentralDir,
+                    zipfile.stringCentralDir,
+                    create_version,
+                    zinfo.create_system,
+                    extract_version,
+                    zinfo.reserved,
+                    zinfo.flag_bits,
+                    zinfo.compress_type,
+                    dostime,
+                    dosdate,
+                    zinfo.CRC,
+                    compress_size,
+                    file_size,
+                    len(zinfo.filename),
+                    len(extra_data),
+                    len(zinfo.comment),
+                    0,
+                    zinfo.internal_attr,
+                    zinfo.external_attr,
+                    header_offset,
+                ),
+                file=sys.stderr,
+            )
+            raise
+        fhandle.write(centdir)
+        fhandle.write(filename)
+        fhandle.write(extra_data)
+        fhandle.write(zinfo.comment)
+
+    pos2 = fhandle.tell()
+
+    # Write end-of-zip-archive record
+    centDirCount = len(zinfos)
+    centDirSize = pos2 - start_dir
+    centDirOffset = start_dir
+
+    requires_zip64 = None
+    if centDirCount > ZIP_FILECOUNT_LIMIT:
+        requires_zip64 = "Files count"
+    elif centDirOffset > ZIP64_LIMIT:
+        requires_zip64 = "Central directory offset"
+    elif centDirSize > ZIP64_LIMIT:
+        requires_zip64 = "Central directory size"
+    if requires_zip64:
+        # Need to write the ZIP64 end-of-archive records
+        zip64endrec = struct.pack(
+            zipfile.structEndArchive64,
+            zipfile.stringEndArchive64,
+            44,
+            45,
+            45,
+            0,
+            0,
+            centDirCount,
+            centDirCount,
+            centDirSize,
+            centDirOffset,
+        )
+        fhandle.write(zip64endrec)
+
+        zip64locrec = struct.pack(
+            zipfile.structEndArchive64Locator,
+            zipfile.stringEndArchive64Locator,
+            0,
+            pos2,
+            1,
+        )
+        fhandle.write(zip64locrec)
+        centDirCount = min(centDirCount, 0xFFFF)
+        centDirSize = min(centDirSize, 0xFFFFFFFF)
+        centDirOffset = min(centDirOffset, 0xFFFFFFFF)
+
+    endrec = struct.pack(
+        zipfile.structEndArchive,
+        zipfile.stringEndArchive,
+        0,
+        0,
+        centDirCount,
+        centDirCount,
+        centDirSize,
+        centDirOffset,
+        len(COMMENT),
+    )
+    fhandle.write(endrec)
+    fhandle.write(COMMENT)
+    fhandle.flush()
+
+
+def _strip_extra(extra, xids):
+    # Remove Extra Fields with specified IDs.
+    unpack = _EXTRA_FIELD_STRUCT.unpack
+    modified = False
+    buffer = []
+    start = i = 0
+    while i + 4 <= len(extra):
+        xid, xlen = unpack(extra[i : i + 4])
+        j = i + 4 + xlen
+        if xid in xids:
+            if i != start:
+                buffer.append(extra[start:i])
+            start = j
+            modified = True
+        i = j
+    if not modified:
+        return extra
+    return b"".join(buffer)

--- a/disk_objectstore/zipsupport.py
+++ b/disk_objectstore/zipsupport.py
@@ -30,6 +30,9 @@ def write_file_describer(fhandle, crc, compressed_size, file_size):
     fhandle.write(struct.pack(fmt, _DD_SIGNATURE, crc, compressed_size, file_size))
 
 
+_DD_SIZE = 24
+
+
 def write_end_record(fhandle, zinfos):
     """
     Write the tailing central directory of contents and the end of zip-archive record
@@ -186,7 +189,7 @@ def write_end_record(fhandle, zinfos):
         len(COMMENT),
     )
     fhandle.write(endrec)
-    fhandle.write(COMMENT)
+    fhandle.write(COMMENT.encode())
     fhandle.flush()
 
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -3351,7 +3351,7 @@ def test_sealing(temp_dir):
     assert temp_container._get_pack_id_to_write_to() == 1
 
     # Sealed pack cannot be sealed again
-    with pytest.raises(ValueError, match="has already been sealed"):
+    with pytest.raises(ValueError, match="been sealed already"):
         temp_container.seal_pack(0)
 
     # Some new data

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1068,9 +1068,7 @@ def test_sizes(
         == total_object_size
     )
 
-    total_header_dd_size = (
-        temp_container._zip_header_size + temp_container._zip_dd_size
-    ) * len(data)
+    total_header_dd_size = (temp_container._zip_header_size) * len(data)
     if compress_packs:
         compressed_data = {}
         for key, val in data.items():

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1066,6 +1066,9 @@ def test_sizes(
         == total_object_size
     )
 
+    total_header_dd_size = (
+        temp_container._zip_header_size + temp_container._zip_dd_size
+    ) * len(data)
     if compress_packs:
         compressed_data = {}
         for key, val in data.items():
@@ -1078,7 +1081,10 @@ def test_sizes(
         size_info = temp_container.get_total_size()
         assert size_info["total_size_packed"] == total_object_size
         assert size_info["total_size_packed_on_disk"] == total_compressed_size
-        assert size_info["total_size_packfiles_on_disk"] == total_compressed_size
+        assert (
+            size_info["total_size_packfiles_on_disk"]
+            == total_compressed_size + total_header_dd_size
+        )
         assert size_info["total_size_packindexes_on_disk"] == os.path.getsize(
             temp_container._get_pack_index_path()
         )
@@ -1087,7 +1093,10 @@ def test_sizes(
         size_info = temp_container.get_total_size()
         assert size_info["total_size_packed"] == total_object_size
         assert size_info["total_size_packed_on_disk"] == total_object_size
-        assert size_info["total_size_packfiles_on_disk"] == total_object_size
+        assert (
+            size_info["total_size_packfiles_on_disk"]
+            == total_object_size + total_header_dd_size
+        )
         assert size_info["total_size_packindexes_on_disk"] == os.path.getsize(
             temp_container._get_pack_index_path()
         )
@@ -1334,7 +1343,7 @@ def test_stream_meta(  # pylint: disable=too-many-locals
                 "size": len(content_packed),
                 "pack_id": 0,  # First pack, it's a new container
                 "pack_compressed": compress,
-                "pack_offset": 0,  # Only one object in the pack, must start from zero
+                "pack_offset": temp_container._zip_header_size,  # Only one object in the pack, must start from zero
                 "pack_length": object_pack_length,
             },
         },
@@ -1450,7 +1459,7 @@ def test_stream_meta_single(temp_container, compress, compression_algorithm):
                 "size": len(content_packed),
                 "pack_id": 0,  # First pack, it's a new container
                 "pack_compressed": compress,
-                "pack_offset": 0,  # Only one object in the pack, must start from zero
+                "pack_offset": temp_container._zip_header_size,  # Only one object in the pack, must start from zero
                 "pack_length": object_pack_length,
             },
         },

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -3339,6 +3339,17 @@ def test_sealing(temp_dir):
         # Check the zipfile
         zif.testzip()
 
+    sealed = temp_container.get_sealed_packs()
+    assert 0 in sealed
+
+    infos = temp_container.get_all_pack_info()
+    assert infos[0]["state"] == "Sealed"
+    assert infos[0]["location"] is None
+    assert infos[0]["pack_id"] == 0
+
+    # Since pack 0 is seal, new data should be written to pack 1
+    assert temp_container._get_pack_id_to_write_to() == 1
+
 
 def test_not_implemented_repacks(temp_container):
     """Check the error for not implemented repack methods."""

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -3046,16 +3046,17 @@ def test_packs_no_holes(
 
     sizes = temp_container.get_total_size()
     assert sizes["total_size_packed"] == len(content1) + len(content2) + len(content3)
-
+    header_size = temp_container._zip_header_size
     if no_holes:
         assert (
-            sizes["total_size_packed_on_disk"] == sizes["total_size_packfiles_on_disk"]
+            sizes["total_size_packed_on_disk"] + header_size * 3
+            == sizes["total_size_packfiles_on_disk"]
         )
     else:
         # We have added twice each object. Note: we cannot use total_size_packed because this would be
         # before compression
         assert (
-            2 * sizes["total_size_packed_on_disk"]
+            2 * (sizes["total_size_packed_on_disk"] + header_size * 3)
             == sizes["total_size_packfiles_on_disk"]
         )
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -2235,6 +2235,7 @@ def test_validate_corrupt_packed(temp_container):
     with open(
         temp_container._get_pack_path_from_pack_id(str(meta["pack_id"])), "wb"
     ) as fhandle:
+        fhandle.seek(temp_container._zip_header_size, 0)
         fhandle.write(b"CORRU890890890809PT")
 
     errors = temp_container.validate()

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -3303,6 +3303,33 @@ def test_repack(temp_dir):
     temp_container.close()
 
 
+def test_sealing(temp_dir):
+    """Test the repacking functionality."""
+    from zipfile import ZipFile
+
+    temp_container = Container(temp_dir)
+    temp_container.init_container(clear=True)
+
+    # data of 10 bytes each. Will fill two packs.
+    data = [
+        b"-123456789",
+        b"a123456789",
+    ]
+    hexkeys = []
+    for value in data:
+        hexkeys.append(temp_container.add_objects_to_pack([value])[0])
+    temp_container.seal_pack("0")
+    temp_container.list_all_objects()
+
+    zif = ZipFile(temp_container._get_pack_path_from_pack_id("0"))
+    for i in range(len(data)):
+        with zif.open(hexkeys[i], mode="r") as fh:
+            zdata = fh.read()
+        assert zdata == data[i]
+    # Check the zipfile
+    zif.testzip()
+
+
 def test_not_implemented_repacks(temp_container):
     """Check the error for not implemented repack methods."""
     # We need to have at least one pack

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -2300,6 +2300,7 @@ def test_validate_corrupt_packed_size(temp_container):  # pylint: disable=invali
         temp_container._get_pack_path_from_pack_id(str(meta["pack_id"])), "wb"
     ) as fhandle:
         # Short corrupted string so also the size is wrong
+        fhandle.write(b" " * temp_container._ZIP_HEADER_SIZE)  # Write a dummy header
         fhandle.write(b"COR")
 
     errors = temp_container.validate()


### PR DESCRIPTION
This PR addresses #124 and potentially also #123. 

The PR is still a work in process. My current aim is to have both two issues addressed here. 

## Brief summary

When writing to pack files, a ZIP-style local header is written before each record. To seal a pack, its integrity is checked and the local headers are updated with checksums, and a central header directory is appended to the end. This operations does not block and any concurrent read access. A new table is introduced to storage the status of each pack file. Technically, writing to a sealed pack works just fine, and the pack can still be resealled, but this would waste some spaces. Hence the table is consulted and sealed packs will not be selected for writing.

After sealing, the pack file becomes a ZIP archive. Each record is a file named by the first 16 characters of its hash value (there can be duplicated names, but the chance is low due to the fine sizes of each sealed pack). The raw data may access by simply extracting the archive using any ZIP compatibe tools. 


