### PR TITLE
implementation for archiving a pack file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,7 @@ repos:
     rev: 21.12b0
     hooks:
     - id: black
+      additional_dependencies: ['click<8.1']
 
   - repo: https://github.com/PyCQA/pylint
     rev: v2.12.2

--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -2855,7 +2855,6 @@ class Container:  # pylint: disable=too-many-public-methods
             .where(Pack.pack_id == pack_id)
             .values(
                 state=PackState.ARCHIVED.value,
-                location=self._get_archive_path_from_pack_id(pack_id),
             )
         )
 
@@ -2896,6 +2895,10 @@ class Container:  # pylint: disable=too-many-public-methods
             return os.path.join(
                 self._get_archive_folder(), self.container_id + "-" + pack_id + ".zip"
             )
+        # We have a location set, it is an relative path we set it relative to the container folder
+        if not Path(pack.location).is_absolute():
+            return os.path.join(self._folder, pack.location)
+
         return pack.location
 
     def _get_archive_folder(self) -> str:
@@ -2972,7 +2975,7 @@ class Container:  # pylint: disable=too-many-public-methods
         """
         paths = {}
         for pack_id in self.get_archived_pack_ids(return_str=True):
-            paths[str(pack_id)] = self._get_pack_path_from_pack_id(pack_id)
+            paths[str(pack_id)] = self._get_archive_path_from_pack_id(pack_id)
         return paths
 
     def _update_archive_location(self, pack_id, location, force=False):

--- a/disk_objectstore/database.py
+++ b/disk_objectstore/database.py
@@ -36,7 +36,7 @@ class PackState(enum.Enum):
     """Enum for valid sate of seal packs"""
 
     ARCHIVED = "Archived"
-    UNSEALED = "Unsealed"
+    ACTIVE = "Active"
 
 
 class Pack(Base):  # pylint: disable=too-few-public-methods
@@ -45,9 +45,8 @@ class Pack(Base):  # pylint: disable=too-few-public-methods
     __tablename__ = "db_pack"
 
     id = Column(Integer, primary_key=True)
-    pack_id = Column(Integer, primary_key=False)
+    pack_id = Column(String, primary_key=False)
     state = Column(String, nullable=False, unique=False)
-    md5 = Column(String, unique=True, nullable=False)
     location = Column(String, nullable=True)
 
 

--- a/disk_objectstore/database.py
+++ b/disk_objectstore/database.py
@@ -1,4 +1,5 @@
 """Models for the container index file (SQLite DB)."""
+import enum
 import os
 from typing import Optional
 
@@ -29,6 +30,25 @@ class Obj(Base):  # pylint: disable=too-few-public-methods
     pack_id = Column(
         Integer, nullable=False
     )  # integer ID of the pack in which this entry is stored
+
+
+class PackState(enum.Enum):
+    """Enum for valid sate of seal packs"""
+
+    ARCHIVED = "Archived"
+    UNSEALED = "Unsealed"
+
+
+class Pack(Base):  # pylint: disable=too-few-public-methods
+    """The table for storing the state of pack files. If missing, it means that the pack is currently active"""
+
+    __tablename__ = "db_pack"
+
+    id = Column(Integer, primary_key=True)
+    pack_id = Column(Integer, primary_key=False)
+    state = Column(String, nullable=False, unique=False)
+    md5 = Column(String, unique=True, nullable=False)
+    location = Column(String, nullable=True)
 
 
 def get_session(

--- a/disk_objectstore/utils.py
+++ b/disk_objectstore/utils.py
@@ -1279,3 +1279,17 @@ def merge_sorted(iterator1: Iterable[Any], iterator2: Iterable[Any]) -> Iterator
     for item, _ in detect_where_sorted(iterator1, iterator2):
         # Whereever it is (only left, only right, on both) I return the object.
         yield item
+
+
+def minimum_length_without_duplication(names, min_length=8):
+    """
+    Find how many characters is needed to ensure there is no conflict among a set of filenames
+    """
+    length = min_length - 1
+    length_ok = False
+    while not length_ok:
+        length += 1
+        trimmed = {name[:length] for name in names}
+        length_ok = len(trimmed) == len(names)
+
+    return length

--- a/disk_objectstore/utils.py
+++ b/disk_objectstore/utils.py
@@ -653,6 +653,14 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
         self._internal_buffer = b""
         self._pos = 0
 
+    def set_zip_mode(self):
+        """Switch to ZIP mode - decompresss with WBITS=-15"""
+        self._decompressor = self.decompressobj_class(-15)
+
+    def set_zlib_mode(self):
+        """Switch to normal operation mode"""
+        self._decompressor = self.decompressobj_class()
+
     @property
     def mode(self) -> str:
         return getattr(self._compressed_stream, "mode", "rb")

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -3518,10 +3518,11 @@ def test_get_pack_id_with_archive(temp_dir):
     # Now, the next object should writ to pack 2, since it is not ful
     assert temp_container._get_pack_id_to_write_to() == 2
     # Mark the third pack as ARCHIVE
+    to_archive = packs[-1].pack_id
     session.execute(
         update(Pack)
-        .where(Pack.id == packs[-1].id)
-        .values(state=PackState.ARCHIVED.value, location="/tmp/2.zip")
+        .where(Pack.pack_id == str(to_archive))
+        .values(state=PackState.ARCHIVED.value, location=f"/tmp/{to_archive}.zip")
     )
     session.commit()
 
@@ -3529,4 +3530,7 @@ def test_get_pack_id_with_archive(temp_dir):
     assert temp_container._get_pack_id_to_write_to() == 3
 
     # Getting the "pack_path" for pack 2 should now point to the custom location
-    assert temp_container._get_pack_path_from_pack_id(2) == "/tmp/2.zip"
+    assert (
+        temp_container._get_pack_path_from_pack_id(to_archive)
+        == f"/tmp/{to_archive}.zip"
+    )

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -3513,6 +3513,15 @@ def test_get_archive_path(temp_container):
     path = temp_container._get_archive_path_from_pack_id(996)
     assert path == "/tmp/archive.zip"
 
+    # Relative path is relative to the container base folder
+    pack = Pack(
+        pack_id="995", state=PackState.ARCHIVED.value, location="archive2/archive.zip"
+    )
+    session.add(pack)
+    session.commit()
+    path = temp_container._get_archive_path_from_pack_id(995)
+    assert path == os.path.join(temp_container._folder, "archive2/archive.zip")
+
 
 def test_get_pack_id_with_archive(temp_dir):
     """Test get_pack_id_to_write_to with archived packs"""

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1073,7 +1073,7 @@ def test_sizes(
 def test_get_objects_stream_closes(temp_container, generate_random_data):
     """Test that get_objects_stream_and_meta closes intermediate streams.
 
-    I also check that at most one additional file is open at any given time.
+    I also check that at most two additional file is open at any given time.
 
     .. note: apparently, at least on my Mac, even if I forget to close a file, this is automatically closed
        when it goes out of scope - so I add also the test that, inside the loop, at most one more file is open.
@@ -1096,7 +1096,7 @@ def test_get_objects_stream_closes(temp_container, generate_random_data):
         obj_md5s.keys(), skip_if_missing=True
     ):
         # I don't use the triplets
-        assert len(current_process.open_files()) <= start_open_files + 1
+        assert len(current_process.open_files()) <= start_open_files + 2
 
     # Check that at the end nothing is left open
     assert len(current_process.open_files()) == start_open_files
@@ -1106,7 +1106,7 @@ def test_get_objects_stream_closes(temp_container, generate_random_data):
     ) as triplets:
         # I loop over the triplets, but I don't do anything
         for _ in triplets:
-            assert len(current_process.open_files()) <= start_open_files + 1
+            assert len(current_process.open_files()) <= start_open_files + 2
 
     # Check that at the end nothing is left open
     assert len(current_process.open_files()) == start_open_files
@@ -1117,7 +1117,7 @@ def test_get_objects_stream_closes(temp_container, generate_random_data):
     ) as triplets:
         # I loop over the triplets, but I don't do anything
         for _, stream, _ in triplets:
-            assert len(current_process.open_files()) <= start_open_files + 1
+            assert len(current_process.open_files()) <= start_open_files + 2
             stream.read()
 
     # Check that at the end nothing is left open
@@ -1134,7 +1134,7 @@ def test_get_objects_stream_closes(temp_container, generate_random_data):
 
     with temp_container.get_objects_stream_and_meta(obj_md5s.keys()):
         # I don't use the triplets
-        assert len(current_process.open_files()) <= start_open_files + 1
+        assert len(current_process.open_files()) <= start_open_files + 2
 
     # Check that at the end nothing is left open
     assert len(current_process.open_files()) == start_open_files
@@ -1142,7 +1142,7 @@ def test_get_objects_stream_closes(temp_container, generate_random_data):
     with temp_container.get_objects_stream_and_meta(obj_md5s.keys()) as triplets:
         # I loop over the triplets, but I don't do anything
         for _ in triplets:
-            assert len(current_process.open_files()) <= start_open_files + 1
+            assert len(current_process.open_files()) <= start_open_files + 2
 
     # Check that at the end nothing is left open
     assert len(current_process.open_files()) == start_open_files
@@ -1153,7 +1153,7 @@ def test_get_objects_stream_closes(temp_container, generate_random_data):
     ) as triplets:
         # I loop over the triplets, but I don't do anything
         for _, stream, _ in triplets:
-            assert len(current_process.open_files()) <= start_open_files + 1
+            assert len(current_process.open_files()) <= start_open_files + 2
             stream.read()
     # Check that at the end nothing is left open
     assert len(current_process.open_files()) == start_open_files

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1680,3 +1680,10 @@ def test_unknown_compressers():
             utils.get_compressobj_instance(invalid)
         with pytest.raises(ValueError):
             utils.get_stream_decompresser(invalid)
+
+
+def test_minimum_length_compute():
+    """Test finding minmum string length without duplication"""
+    assert utils.minimum_length_without_duplication(["a", "b"]) == 8
+    assert utils.minimum_length_without_duplication(["aaaaaaaa", "bbbbbbbb"]) == 8
+    assert utils.minimum_length_without_duplication(["aaaaaaaac", "aaaaaaaab"]) == 9


### PR DESCRIPTION
Replaces #133 

Archived pack files are essentially ZIP archives. Reading from these files are also supported from offset/length as stored in the sqlite database. Because archived packs will never be used for reading, they can be stored at different file systems and networked locations. The use of ZIP archives also allows recovering data in case of the sqlite database being damaged. 

The main difference between an archived pack and a normal pack is that:

1. An archived pack file is always compressed.
2. Compression is done by DEFLATE, but the stream is slightly different from that of a normal pack file. This is because in normal pack file compressed streams contains zlib's header/trailer (WBITTS=15, default), while for a ZIP file the streams are "raw" adn does not contain headers/trailers  (WBITS=-15). 
 
Creating an archive is a slow process, and should be carried out while the container is not activet (e.g. similar to repack). However, I think it is should still be possible to carry out as long as the pack file being archived not being written into at the same time. 

A new table is needed in the sqlite database to store the status of the pack file, with two extra columns: `state` and `location`. The former would be changed to `Archived` if the pack is archived. The latter stores any explicit location of the archived pack file.

A cli interface is provided to list archive files and update their locations. 