### PR TITLE
Add whence=2 to be used

### DIFF
--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -659,7 +659,9 @@ class Container:  # pylint: disable=too-many-public-methods
                             length=metadata.length,
                         )
                         if metadata.compressed:
-                            obj_reader = self._get_stream_decompresser()(obj_reader)
+                            obj_reader = self._get_stream_decompresser()(
+                                obj_reader, container=self, hashkey=metadata.hashkey
+                            )
                         yield metadata.hashkey, obj_reader, meta
                     else:
                         yield metadata.hashkey, meta
@@ -799,7 +801,9 @@ class Container:  # pylint: disable=too-many-public-methods
                                 length=metadata.length,
                             )
                             if metadata.compressed:
-                                obj_reader = self._get_stream_decompresser()(obj_reader)
+                                obj_reader = self._get_stream_decompresser()(
+                                    obj_reader, container=self, hashkey=metadata.hashkey
+                                )
                             yield metadata.hashkey, obj_reader, meta
                         else:
                             yield metadata.hashkey, meta
@@ -1846,6 +1850,28 @@ class Container:  # pylint: disable=too-many-public-methods
             do_fsync=do_fsync,
             do_commit=do_commit,
         )
+
+    def _lossen_object(self, hashkey):
+        """
+        Write a specific object to the loose directory, return the path to the loose file
+        """
+        _read_chunk_size = 524288
+
+        # Here I just use a new object writer that writes the stream as loose file
+        writer = self._new_object_writer()
+
+        with self.get_object_stream(hashkey) as stream:
+            with writer as fhandle:
+                while True:
+                    chunk = stream.read(_read_chunk_size)
+                    if not chunk:
+                        break
+                    fhandle.write(chunk)
+            written_hashkey = writer.get_hashkey()
+            assert (
+                written_hashkey == hashkey
+            ), "Mismatch in the hashkey - something is seriously wrong"
+        return self._get_loose_path_from_hashkey(hashkey)
 
     def _vacuum(self) -> None:
         """Perform a `VACUUM` operation on the SQLite operation.

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -293,6 +293,14 @@ def test_stream_seek(temp_container, use_compression, use_packing):
         stream.seek(offset, 1)
         assert stream.read() == content[(10 + 3) :]
 
+        # Test whence=2, by first seeking to the tenth byte, seeking 3 from the end
+        stream.seek(10)
+        offset = -3
+        stream.seek(offset, 2)
+        assert stream.read() == content[offset:]
+        # Check that we have lossen the file
+        assert os.path.isfile(temp_container._get_loose_path_from_hashkey(hashkey))
+
 
 def test_num_packs_with_target_size(temp_dir, generate_random_data):
     """Add a number of objects directly to packs, with a small pack_size_target.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -980,9 +980,9 @@ def test_packed_object_reader_seek(tmp_path):
         # Check that it is properly marked as seekable
         assert packed_reader.seekable()
 
-        # Check that whence==2 is not implemented
-        with pytest.raises(NotImplementedError):
-            packed_reader.seek(0, 2)
+        # Check that whence==2 is implemented
+        packed_reader.seek(-2, 2)
+        assert packed_reader.read() == bytestream[offset + length - 2 : offset + length]
 
         # Check that negative values and values > length are not valid
         with pytest.raises(ValueError):


### PR DESCRIPTION
Addresses #136 

For reading packed file as it is, there is no need to restrict whence to be only 0 or 1.

Compressed files are more tricky as it is not possible to freely seek to the end. Instead, the entire files will be decompressed back
into a loose file, which will then be opened for reading.

If such file exists already it will be used, so we don't decompress twice. Such "cache" files are deleted during the routine maintainance operations (e.g. pack_all_loose).

However, this does add some coupling between the `Decompressor` and the `Container` as the former has to have access to the latter to be able to obtain decompressed stream. 
