### PR TITLE
Dependencies: Unpin `sqlalchemy`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ keywords = ['object store', 'repository', 'file store', 'key-value store']
 requires-python = '>=3.8'
 dependencies = [
     'click',
-    'sqlalchemy~=1.4.22',
+    'sqlalchemy>=1.4.22',
 ]
 
 [project.urls]


### PR DESCRIPTION
The package is also compatible with v2.0 so we relax the requirement and allow `sqlalchemy>=1.4.22`.

~~Blocked by #159~~