### PR TITLE
Devops: Fix the ReadTheDocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,16 @@
 version: 2
 
+build:
+    os: ubuntu-22.04
+    tools:
+        python: '3.8'
+
 # We disable all unneeded formats.
 # Note that HTML and JSON are always built: https://docs.readthedocs.io/en/latest/yaml-config.html#formats
 formats: []
 
 # Need to install the package itself such that the entry points are installed and the API doc can build properly
 python:
-    version: 3.8
     install:
         - method: pip
           path: .


### PR DESCRIPTION
The new config requires `build.os` to be specified: https://blog.readthedocs.com/use-build-os-config/