### PR TITLE
Backup tools: rsync progress; logging change 

### DIFF
--- a/disk_objectstore/__init__.py
+++ b/disk_objectstore/__init__.py
@@ -2,7 +2,12 @@
 
 It does not require a server running.
 """
+
+import logging
+
 from .container import CompressMode, Container, ObjectType
+
+LOGGER = logging.getLogger(__name__)
 
 __all__ = ("Container", "ObjectType", "CompressMode")
 

--- a/disk_objectstore/backup_utils.py
+++ b/disk_objectstore/backup_utils.py
@@ -80,6 +80,8 @@ class BackupManager:
                     f"Input validation failed: Couldn't access/create '{str(self.path)}'!"
                 )
 
+        self.rsync_version = self.get_rsync_major_version()
+
     def check_if_remote_accessible(self):
         """Check if remote host is accessible via ssh"""
         LOGGER.info("Checking if '%s' is accessible...", self.remote)
@@ -165,8 +167,7 @@ class BackupManager:
         capture_output = True
         if LOGGER.isEnabledFor(logging.INFO):
             capture_output = False
-            rsync_version = self.get_rsync_major_version()
-            if rsync_version and rsync_version >= 3:
+            if self.rsync_version and self.rsync_version >= 3:
                 # These options show progress in a nicer way but
                 # they're only available for rsync version 3+
                 all_args += ["--info=progress2,stats1"]

--- a/disk_objectstore/backup_utils.py
+++ b/disk_objectstore/backup_utils.py
@@ -14,9 +14,10 @@ import tempfile
 from pathlib import Path
 from typing import Callable, Optional
 
+from disk_objectstore import LOGGER as BASE_LOGGER
 from disk_objectstore.container import Container
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = BASE_LOGGER.getChild(__name__)
 
 
 class BackupError(Exception):

--- a/disk_objectstore/backup_utils.py
+++ b/disk_objectstore/backup_utils.py
@@ -15,8 +15,7 @@ from typing import Callable, Optional
 
 from disk_objectstore.container import Container
 
-logging.basicConfig(format="%(levelname)s:%(message)s")
-backup_logger = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 class BackupError(Exception):
@@ -49,13 +48,11 @@ class BackupManager:
     def __init__(
         self,
         dest: str,
-        logger: logging.Logger,
         keep: int = 1,
         rsync_exe: Optional[str] = None,
     ) -> None:
         self.dest = dest
         self.keep = keep
-        self.logger = logger
         self.remote, self.path = split_remote_and_path(dest)
         self.rsync_exe = rsync_exe if rsync_exe is not None else "rsync"
 
@@ -83,11 +80,11 @@ class BackupManager:
 
     def check_if_remote_accessible(self):
         """Check if remote host is accessible via ssh"""
-        self.logger.info(f"Checking if '{self.remote}' is accessible...")
+        LOGGER.info("Checking if '%s' is accessible...", self.remote)
         success = self.run_cmd(["exit"])[0]
         if not success:
             raise BackupError(f"Remote '{self.remote}' is not accessible!")
-        self.logger.info("Success! '%s' is accessible!", self.remote)
+        LOGGER.info("Success! '%s' is accessible!", self.remote)
 
     def check_path_exists(self, path: Path) -> bool:
         cmd = ["[", "-e", str(path), "]"]
@@ -106,10 +103,12 @@ class BackupManager:
 
         res = subprocess.run(all_args, capture_output=True, text=True, check=False)
 
-        self.logger.debug(
-            f"Command: {all_args}\n"
-            f"  Exit Code: {res.returncode}\n"
-            f"  stdout/stderr: {res.stdout}\n{res.stderr}"
+        LOGGER.debug(
+            "Command: %s\n  Exit Code: %d\n  stdout/stderr: %s\n%s",
+            str(all_args),
+            res.returncode,
+            res.stdout,
+            res.stderr,
         )
 
         success = res.returncode == 0
@@ -137,10 +136,16 @@ class BackupManager:
         :param dest_trailing_slash:
             Add a trailing slash to the destination path. This makes rsync interpret the
             destination as a folder and create it if it doesn't exists.
-
         """
 
-        all_args = [self.rsync_exe, "-azh", "-vv", "--no-whole-file"]
+        all_args = [
+            self.rsync_exe,
+            "-azh",
+            "--no-whole-file",
+            "--info=progress2,stats1",
+        ]
+        if LOGGER.isEnabledFor(logging.DEBUG):
+            all_args += ["-vv"]
         if extra_args:
             all_args += extra_args
         if link_dest:
@@ -163,15 +168,21 @@ class BackupManager:
         else:
             all_args += [f"{self.remote}:{dest_str}"]
 
-        res = subprocess.run(all_args, capture_output=True, text=True, check=False)
+        cmd_str = " ".join(all_args)
+        LOGGER.info("Running '%s'", cmd_str)
 
-        self.logger.debug(
-            "Command: %s\n  Exit Code: %s\n  stdout/stderr: %s\n%s",
-            str(all_args),
-            res.returncode,
-            res.stdout,
-            res.stderr,
+        capture_output = True
+        if LOGGER.isEnabledFor(logging.INFO):
+            capture_output = False
+
+        res = subprocess.run(
+            all_args, capture_output=capture_output, text=True, check=False
         )
+
+        info_text = f"rsync completed. Exit Code: {res.returncode}"
+        if capture_output:
+            info_text += f"\nstdout/stderr: {res.stdout}\n{res.stderr}"
+        LOGGER.info(info_text)
 
         if res.returncode != 0:
             raise BackupError(f"rsync failed for: {str(src)} to {str(dest)}")
@@ -214,9 +225,9 @@ class BackupManager:
         for folder in to_delete:
             success = self.run_cmd(["rm", "-rf", folder])[0]
             if success:
-                self.logger.info(f"Deleted old backup: {folder}")
+                LOGGER.info("Deleted old backup: %s", folder)
             else:
-                self.logger.warning("Warning: couldn't delete old backup: %s", folder)
+                LOGGER.warning("Warning: couldn't delete old backup: %s", folder)
 
     def backup_auto_folders(self, backup_func: Callable) -> None:
         """Create a backup, managing live and previous backup folders automatically
@@ -237,11 +248,11 @@ class BackupManager:
         last_folder = self.get_last_backup_folder()
 
         if last_folder:
-            self.logger.info(
-                f"Last backup is '{str(last_folder)}', using it for rsync --link-dest."
+            LOGGER.info(
+                "Last backup is '%s', using it for rsync --link-dest.", str(last_folder)
             )
         else:
-            self.logger.info("Couldn't find a previous backup to increment from.")
+            LOGGER.info("Couldn't find a previous backup to increment from.")
 
         backup_func(
             live_folder,
@@ -263,8 +274,10 @@ class BackupManager:
                 f"Failed to move '{str(live_folder)}' to '{str(self.path / folder_name)}'"
             )
 
-        self.logger.info(
-            f"Backup moved from '{str(live_folder)}' to '{str(self.path / folder_name)}'."
+        LOGGER.info(
+            "Backup moved from '%s' to '%s'.",
+            str(live_folder),
+            str(self.path / folder_name),
         )
 
         symlink_name = "last-backup"
@@ -272,11 +285,12 @@ class BackupManager:
             ["ln", "-sfn", str(folder_name), str(self.path / symlink_name)]
         )[0]
         if not success:
-            self.logger.warning(
-                f"Couldn't create symlink '{symlink_name}'. Perhaps the filesystem doesn't support it."
+            LOGGER.warning(
+                "Couldn't create symlink '%s'. Perhaps the filesystem doesn't support it.",
+                symlink_name,
             )
         else:
-            self.logger.info(f"Added symlink '{symlink_name}' to '{folder_name}'.")
+            LOGGER.info("Added symlink '%s' to '%s'.", symlink_name, folder_name)
 
         self.delete_old_backups()
 
@@ -321,7 +335,7 @@ def backup_container(
     prev_backup_loose = prev_backup / loose_path_rel if prev_backup else None
 
     manager.call_rsync(loose_path, path, link_dest=prev_backup_loose)
-    manager.logger.info(f"Transferred {str(loose_path)} to {str(path)}")
+    LOGGER.info("Transferred %s to %s", str(loose_path), str(path))
 
     # step 2: back up sqlite db
 
@@ -331,18 +345,18 @@ def backup_container(
         _sqlite_backup(sqlite_path, sqlite_temp_loc)
 
         if sqlite_temp_loc.is_file():
-            manager.logger.info(f"Dumped the SQLite database to {str(sqlite_temp_loc)}")
+            LOGGER.info("Dumped the SQLite database to %s", str(sqlite_temp_loc))
         else:
             raise BackupError(f"'{str(sqlite_temp_loc)}' failed to be created.")
 
         # step 3: transfer the SQLITE database file
         manager.call_rsync(sqlite_temp_loc, path, link_dest=prev_backup)
-        manager.logger.info(f"Transferred SQLite database to {str(path)}")
+        LOGGER.info("Transferred SQLite database to %s", str(path))
 
     # step 4: transfer the packed files
     packs_path_rel = packs_path.relative_to(container_root_path)
     manager.call_rsync(packs_path, path, link_dest=prev_backup)
-    manager.logger.info(f"Transferred {str(packs_path)} to {str(path)}")
+    LOGGER.info("Transferred %s to %s", str(packs_path), str(path))
 
     # step 5: transfer anything else in the container folder
     manager.call_rsync(

--- a/disk_objectstore/cli.py
+++ b/disk_objectstore/cli.py
@@ -233,18 +233,20 @@ def backup(
     non-UNIX environments.
     """
 
+    logging.basicConfig(format="%(levelname)s:%(message)s")
+    logger = logging.getLogger("disk_objectstore.backup_utils")
+
     if verbosity == "silent":
-        backup_utils.backup_logger.setLevel(logging.ERROR)
+        logger.setLevel(logging.ERROR)
     elif verbosity == "info":
-        backup_utils.backup_logger.setLevel(logging.INFO)
+        logger.setLevel(logging.INFO)
     elif verbosity == "debug":
-        backup_utils.backup_logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.DEBUG)
 
     with dostore.container as container:
         try:
             backup_manager = backup_utils.BackupManager(
                 dest,
-                backup_utils.backup_logger,
                 keep=keep,
                 rsync_exe=rsync_exe,
             )

--- a/disk_objectstore/cli.py
+++ b/disk_objectstore/cli.py
@@ -234,7 +234,7 @@ def backup(
     """
 
     logging.basicConfig(format="%(levelname)s:%(message)s")
-    logger = logging.getLogger("disk_objectstore.backup_utils")
+    logger = logging.getLogger("disk_objectstore")
 
     if verbosity == "silent":
         logger.setLevel(logging.ERROR)

--- a/disk_objectstore/cli.py
+++ b/disk_objectstore/cli.py
@@ -1,4 +1,5 @@
 """A small CLI tool for managing stores."""
+
 import dataclasses
 import json
 import logging
@@ -228,7 +229,7 @@ def backup(
     by OpenSSH, such as adding configuration options to ~/.ssh/config (e.g. to allow for passwordless
     login - recommended, since this script might ask multiple times for the password).
 
-    NOTE: 'rsync' and other UNIX-specific commands are called, thus the command will not work on
+    NOTE: 'rsync' and other UNIX-specific commands are called, thus the command will likely not work on
     non-UNIX environments.
     """
 
@@ -244,8 +245,8 @@ def backup(
             backup_manager = backup_utils.BackupManager(
                 dest,
                 backup_utils.backup_logger,
-                exes={"rsync": rsync_exe},
                 keep=keep,
+                rsync_exe=rsync_exe,
             )
             backup_manager.backup_auto_folders(
                 lambda path, prev: backup_utils.backup_container(

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -47,7 +47,7 @@ def test_inaccessible_exe():
     dest = "/tmp/test"
     rsync_exe = f"_{_random_string()}"
     with pytest.raises(ValueError, match=f"{rsync_exe} not accessible."):
-        BackupManager(dest, backup_utils.backup_logger, exes={"rsync": rsync_exe})
+        BackupManager(dest, backup_utils.backup_logger, rsync_exe=rsync_exe)
 
 
 def test_inaccessible_path():

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -6,6 +6,7 @@ import logging
 import platform
 import random
 import string
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -114,6 +115,17 @@ def test_rsync_legacy_progress(monkeypatch, temp_dir, capfd):
 
     assert (dest2 / fname).exists()
     assert fname in captured.out
+
+
+def test_get_rsync_major_version_failure(monkeypatch):
+    """Test case where rsync version fails."""
+
+    def mock_subprocess_run(*args, **_kwargs):
+        return subprocess.CompletedProcess(args, 0, "unexpected", "")
+
+    monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
+    manager = BackupManager("/tmp")
+    assert manager.get_rsync_major_version() is None
 
 
 def test_existing_backups_failure():

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -25,21 +25,21 @@ def test_invalid_destination():
     """Test invalid destination with two colons."""
     dest = "localhost:/tmp/test:"
     with pytest.raises(ValueError, match="Invalid destination format"):
-        BackupManager(dest, backup_utils.backup_logger)
+        BackupManager(dest)
 
 
 def test_inaccessible_remote():
     """Test a remote destination of random characters that will not be accessible."""
     dest = f"_{_random_string()}:/tmp/test"
     with pytest.raises(BackupError, match="is not accessible"):
-        BackupManager(dest, backup_utils.backup_logger)
+        BackupManager(dest)
 
 
 def test_negative_keep():
     """Test a negative keep value."""
     dest = "/tmp/test"
     with pytest.raises(ValueError, match="keep variable can't be negative"):
-        BackupManager(dest, backup_utils.backup_logger, keep=-1)
+        BackupManager(dest, keep=-1)
 
 
 def test_inaccessible_exe():
@@ -47,21 +47,21 @@ def test_inaccessible_exe():
     dest = "/tmp/test"
     rsync_exe = f"_{_random_string()}"
     with pytest.raises(ValueError, match=f"{rsync_exe} not accessible."):
-        BackupManager(dest, backup_utils.backup_logger, rsync_exe=rsync_exe)
+        BackupManager(dest, rsync_exe=rsync_exe)
 
 
 def test_inaccessible_path():
     """Test case where path is not accessible."""
     dest = f"/_{_random_string()}"  # I assume there will be a permission error for this path
     with pytest.raises(ValueError, match=f"Couldn't access/create '{dest}'"):
-        BackupManager(dest, backup_utils.backup_logger)
+        BackupManager(dest)
 
 
 def test_rsync_failure():
     """Test case where rsync fails."""
     dest = "/tmp/test"
     with pytest.raises(BackupError, match="rsync failed"):
-        manager = BackupManager(dest, backup_utils.backup_logger)
+        manager = BackupManager(dest)
         # pick a src that doesn't exists
         manager.call_rsync(Path(f"/_{_random_string()}"), Path(dest))
 
@@ -71,7 +71,7 @@ def test_rsync_dest_trailing_slash(temp_dir):
     dest1 = Path(temp_dir) / "dest1"
     dest2 = Path(temp_dir) / "dest2"
     # manager will create dest1 folder
-    manager = BackupManager(str(dest1), backup_utils.backup_logger)
+    manager = BackupManager(str(dest1))
     # dest_trailing_slash=True will create dest2
     manager.call_rsync(dest1, dest2, dest_trailing_slash=True)
     assert dest2.exists()
@@ -81,7 +81,7 @@ def test_existing_backups_failure():
     """Test case where existing backups fail to be determined."""
     dest = "/tmp/test"
     with pytest.raises(BackupError, match="Existing backups determination failed"):
-        manager = BackupManager(dest, backup_utils.backup_logger)
+        manager = BackupManager(dest)
         # override the path to something that will fail
         manager.path = f"/_{_random_string()}"
         manager.get_existing_backup_folders()
@@ -108,7 +108,7 @@ def test_sqlite_failure(monkeypatch, temp_container, temp_dir):
 
     dest = Path(temp_dir) / "backup"
     with pytest.raises(BackupError, match="'.*' failed to be created."):
-        manager = BackupManager(str(dest), backup_utils.backup_logger)
+        manager = BackupManager(str(dest))
         manager.backup_auto_folders(
             lambda path, prev: backup_utils.backup_container(
                 manager, temp_container, path, prev
@@ -145,7 +145,7 @@ def test_mv_failure(monkeypatch, temp_container, temp_dir):
 
     dest = Path(temp_dir) / "backup"
     with pytest.raises(BackupError, match="Failed to move"):
-        manager = BackupManager(str(dest), backup_utils.backup_logger)
+        manager = BackupManager(str(dest))
         manager.backup_auto_folders(
             lambda path, prev: backup_utils.backup_container(
                 manager, temp_container, path, prev
@@ -181,7 +181,7 @@ def test_ln_failure(monkeypatch, temp_container, temp_dir, caplog):
         temp_container.add_object(f"test-{idx}".encode())
 
     dest = Path(temp_dir) / "backup"
-    manager = BackupManager(str(dest), backup_utils.backup_logger)
+    manager = BackupManager(str(dest))
     manager.backup_auto_folders(
         lambda path, prev: backup_utils.backup_container(
             manager, temp_container, path, prev
@@ -219,7 +219,7 @@ def test_rm_failure(monkeypatch, temp_container, temp_dir, caplog):
         temp_container.add_object(f"test-{idx}".encode())
 
     dest = Path(temp_dir) / "backup"
-    manager = BackupManager(str(dest), backup_utils.backup_logger, keep=0)
+    manager = BackupManager(str(dest), keep=0)
     for _ in range(2):
         manager.backup_auto_folders(
             lambda path, prev: backup_utils.backup_container(

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -68,10 +68,10 @@ def test_rsync_failure():
         manager.call_rsync(Path(f"/_{_random_string()}"), Path(dest))
 
 
-def test_rsync_dest_trailing_slash(temp_dir):
+def test_rsync_dest_trailing_slash(tmp_path):
     """Test case for dest_trailing_slash."""
-    dest1 = Path(temp_dir) / "dest1"
-    dest2 = Path(temp_dir) / "dest2"
+    dest1 = tmp_path / "dest1"
+    dest2 = tmp_path / "dest2"
     # manager will create dest1 folder
     manager = BackupManager(str(dest1))
     # dest_trailing_slash=True will create dest2
@@ -79,7 +79,7 @@ def test_rsync_dest_trailing_slash(temp_dir):
     assert dest2.exists()
 
 
-def test_rsync_legacy_progress(monkeypatch, temp_dir, capfd):
+def test_rsync_legacy_progress(monkeypatch, tmp_path, capfd):
     """Test case where rsync version is less than 3.
 
     In this case, 'rsync --progress' is used, that prints each transferred file
@@ -98,8 +98,8 @@ def test_rsync_legacy_progress(monkeypatch, temp_dir, capfd):
         mock_get_rsync_major_version,
     )
 
-    dest1 = Path(temp_dir) / "dest1"
-    dest2 = Path(temp_dir) / "dest2"
+    dest1 = tmp_path / "dest1"
+    dest2 = tmp_path / "dest2"
 
     dest1.mkdir(parents=True)
 
@@ -138,7 +138,7 @@ def test_existing_backups_failure():
         manager.get_existing_backup_folders()
 
 
-def test_sqlite_failure(monkeypatch, temp_container, temp_dir):
+def test_sqlite_failure(monkeypatch, temp_container, tmp_path):
     """Test case where sqlite fails to make a backup file."""
 
     # monkeypatch sqlite backup to do nothing
@@ -157,7 +157,7 @@ def test_sqlite_failure(monkeypatch, temp_container, temp_dir):
     for idx in range(100):
         temp_container.add_object(f"test-{idx}".encode())
 
-    dest = Path(temp_dir) / "backup"
+    dest = tmp_path / "backup"
     with pytest.raises(BackupError, match="'.*' failed to be created."):
         manager = BackupManager(str(dest))
         manager.backup_auto_folders(
@@ -167,7 +167,7 @@ def test_sqlite_failure(monkeypatch, temp_container, temp_dir):
         )
 
 
-def test_mv_failure(monkeypatch, temp_container, temp_dir):
+def test_mv_failure(monkeypatch, temp_container, tmp_path):
     """
     Test case where mv command fails by monkeypatching.
     Make sure correct BackupError is raised.
@@ -194,7 +194,7 @@ def test_mv_failure(monkeypatch, temp_container, temp_dir):
     for idx in range(100):
         temp_container.add_object(f"test-{idx}".encode())
 
-    dest = Path(temp_dir) / "backup"
+    dest = tmp_path / "backup"
     with pytest.raises(BackupError, match="Failed to move"):
         manager = BackupManager(str(dest))
         manager.backup_auto_folders(
@@ -204,7 +204,7 @@ def test_mv_failure(monkeypatch, temp_container, temp_dir):
         )
 
 
-def test_ln_failure(monkeypatch, temp_container, temp_dir, caplog):
+def test_ln_failure(monkeypatch, temp_container, tmp_path, caplog):
     """
     Test case where ln command fails by monkeypatching.
     Make sure correct warning is logged.
@@ -231,7 +231,7 @@ def test_ln_failure(monkeypatch, temp_container, temp_dir, caplog):
     for idx in range(100):
         temp_container.add_object(f"test-{idx}".encode())
 
-    dest = Path(temp_dir) / "backup"
+    dest = tmp_path / "backup"
     manager = BackupManager(str(dest))
     manager.backup_auto_folders(
         lambda path, prev: backup_utils.backup_container(
@@ -241,7 +241,7 @@ def test_ln_failure(monkeypatch, temp_container, temp_dir, caplog):
     assert "Couldn't create symlink" in caplog.text
 
 
-def test_rm_failure(monkeypatch, temp_container, temp_dir, caplog):
+def test_rm_failure(monkeypatch, temp_container, tmp_path, caplog):
     """
     Test case where rm command fails by monkeypatching.
     Make sure correct warning is logged.
@@ -269,7 +269,7 @@ def test_rm_failure(monkeypatch, temp_container, temp_dir, caplog):
     for idx in range(100):
         temp_container.add_object(f"test-{idx}".encode())
 
-    dest = Path(temp_dir) / "backup"
+    dest = tmp_path / "backup"
     manager = BackupManager(str(dest), keep=0)
     for _ in range(2):
         manager.backup_auto_folders(


### PR DESCRIPTION
Hi,

this PR contains two changes:

**1)** remove the logger argument from BackupManager, and instead only use the logger object of this library. 

This change is motivated by the fact that in aiida-core, the default logging level is REPORT (23) and the logger.info messages of this library are not outputted, which give information about the progress and should probably be shown by default. After these changes, the logger instead should be controlled in the aiida-core via something like

```python
    import logging
    from aiida.common.log import LOG_LEVEL_REPORT
    DOS_BACKUP_LOGGER = logging.getLogger("disk_objectstore.backup_utils")
    # As the default logging level in AiiDA is a custom level REPORT (23), adapt
    # the disk-objectstore logger to output the INFO (20) level by default as well
    storage_logger_level = STORAGE_LOGGER.getEffectiveLevel()
    if storage_logger_level  >= logging.INFO and storage_logger_level <= LOG_LEVEL_REPORT:
        DOS_BACKUP_LOGGER.setLevel(logging.INFO)
    else:
        DOS_BACKUP_LOGGER.setLevel(storage_logger_level)
    
    handler = logging.StreamHandler()
    formatter = logging.Formatter('%(name)s: [%(levelname)s] %(message)s')
    handler.setFormatter(formatter)

    DOS_BACKUP_LOGGER.addHandler(handler)
```

Although, perhaps there is a better way to do it, similarly to the other loggers (as is done in aiida.common.log.py).

In principle, I can also revert to using the logger argument, but then i probably should also create a custom log level called REPORT in this library, if i want to log consistently with aiida-core.

**2)** Enable rsync progress indication (with `--info=progress2`) and output the stdout directly to the user, without capturing it

If i call `subprocess.run(rsync_args, capture_output=False)`, the stdout of rsync is passed directly from the subprocess to the user, bypassing any logging system. Although this has drawbacks (e.g. it won't show up in logs, e.g. when redirecting to a file), it allows to show the updating progress indicator to the user running the CLI sees. The output is captured and not shown, however, if the logging level is above INFO. The motivation behind why I just bypass capturing the output is that if the stdout is captured, it's not possible (i think; or at least not without writing a lot of code) to output a in-place updating progress indicator via the logging system.

As this has the drawback, I think it would be good to discuss and get opinions (@giovannipizzi @sphuber).

Two possible alternatives would be

* capturing the progress output and logging each line of the progress updates. the user will get a lot of output, like
```
disk_objectstore.backup_utils: [INFO] 32.77K  96%   15.29MB/s    0:00:00 (xfr#2, to-chk=0/14
disk_objectstore.backup_utils: [INFO] 32.77K  97%   15.29MB/s    0:00:00 (xfr#2, to-chk=0/14
disk_objectstore.backup_utils: [INFO] 32.77K  98%   15.29MB/s    0:00:00 (xfr#2, to-chk=0/14
...
``` 
* capturing the output of rsync, parsing it and getting the progress percentage, and implementing some progressbar in python (e.g. tqdm), similar to what is done in aiida-core. But perhaps this is a lot of code and would bloat the library a bit too much.