### PR TITLE
Progress bar for `repack` and `pack_all_loose`

### DIFF
--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -2,6 +2,8 @@
 The main implementation of the ``Container`` class of the object store.
 """
 
+from __future__ import annotations
+
 # pylint: disable=too-many-lines
 import dataclasses
 import io
@@ -13,21 +15,7 @@ from collections import defaultdict, namedtuple
 from contextlib import contextmanager
 from enum import Enum
 from pathlib import Path
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterator,
-    List,
-    Literal,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Type,
-    Union,
-    overload,
-)
+from typing import TYPE_CHECKING, overload
 
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql import func
@@ -62,6 +50,24 @@ from .utils import (
     should_compress,
     yield_first_element,
 )
+
+if TYPE_CHECKING:
+    from typing import (
+        Any,
+        Callable,
+        Dict,
+        Iterator,
+        List,
+        Literal,
+        Optional,
+        Sequence,
+        Set,
+        Tuple,
+        Type,
+        Union,
+    )
+
+    from mypy_extensions import Arg
 
 ObjQueryResults = namedtuple(
     "ObjQueryResults", ["hashkey", "offset", "length", "compressed", "size"]
@@ -107,19 +113,19 @@ class Container:  # pylint: disable=too-many-public-methods
     # (after VACUUMing, as mentioned above).
     _MAX_CHUNK_ITERATE_LENGTH = 9500
 
-    def __init__(self, folder: Union[str, Path]) -> None:
+    def __init__(self, folder: str | Path) -> None:
         """Create the class that represents the container.
 
         :param folder: the path to a folder that will host this object-store container.
         """
         self._folder = Path(folder).resolve()
         # Will be populated by the _get_session function
-        self._session: Optional[Session] = None
+        self._session: Session | None = None
 
         # These act as caches and will be populated by the corresponding properties
         # IMPORANT! IF YOU ADD MORE, REMEMBER TO CLEAR THEM IN `init_container()`!
-        self._current_pack_id: Optional[int] = None
-        self._config: Optional[dict] = None
+        self._current_pack_id: int | None = None
+        self._config: dict | None = None
 
     def get_folder(self) -> Path:
         """Return the path to the folder that will host the object-store container."""
@@ -131,7 +137,7 @@ class Container:  # pylint: disable=too-many-public-methods
             self._session.close()
             self._session = None
 
-    def __enter__(self) -> "Container":
+    def __enter__(self) -> Container:
         """Return a context manager that will close the session when exiting the context."""
         return self
 
@@ -183,12 +189,12 @@ class Container:  # pylint: disable=too-many-public-methods
     @overload
     def _get_session(
         self, create: bool = False, raise_if_missing: Literal[False] = False
-    ) -> Optional[Session]:
+    ) -> Session | None:
         ...
 
     def _get_session(
         self, create: bool = False, raise_if_missing: bool = False
-    ) -> Optional[Session]:
+    ) -> Session | None:
         """Return a new session to connect to the pack-index SQLite DB.
 
         :param create: if True, creates the sqlite file and schema.
@@ -226,7 +232,7 @@ class Container:  # pylint: disable=too-many-public-methods
         return self._get_loose_folder() / hashkey
 
     def _get_pack_path_from_pack_id(
-        self, pack_id: Union[str, int], allow_repack_pack: bool = False
+        self, pack_id: str | int, allow_repack_pack: bool = False
     ) -> Path:
         """Return the path of the pack file on disk for the given pack ID.
 
@@ -387,7 +393,7 @@ class Container:  # pylint: disable=too-many-public-methods
 
         self._get_session(create=True)
 
-    def _get_repository_config(self) -> Dict[str, Union[int, str]]:
+    def _get_repository_config(self) -> dict[str, int | str]:
         """Return the repository config."""
         if self._config is None:
             if not self.is_initialised:
@@ -445,7 +451,7 @@ class Container:  # pylint: disable=too-many-public-methods
         """Return the correct `compressobj` class for the compression algorithm defined for this container."""
         return get_compressobj_instance(self.compression_algorithm)
 
-    def _get_stream_decompresser(self) -> Type[ZlibStreamDecompresser]:
+    def _get_stream_decompresser(self) -> type[ZlibStreamDecompresser]:
         """Return a new instance of the correct StreamDecompresser class for the compression algorithm
         defined for this container.
         """
@@ -480,7 +486,7 @@ class Container:  # pylint: disable=too-many-public-methods
     @contextmanager
     def get_object_stream_and_meta(
         self, hashkey: str
-    ) -> Iterator[Tuple[StreamReadBytesType, ObjectMeta],]:
+    ) -> Iterator[tuple[StreamReadBytesType, ObjectMeta],]:
         """Return a context manager yielding a stream to get the content of an object, and a metadata dictionary.
 
         To be used as a context manager::
@@ -522,7 +528,7 @@ class Container:  # pylint: disable=too-many-public-methods
         hashkeys: Sequence[str],
         skip_if_missing: bool,
         with_streams: Literal[False],
-    ) -> Iterator[Tuple[str, ObjectMeta]]:
+    ) -> Iterator[tuple[str, ObjectMeta]]:
         ...
 
     @overload
@@ -531,7 +537,7 @@ class Container:  # pylint: disable=too-many-public-methods
         hashkeys: Sequence[str],
         skip_if_missing: bool,
         with_streams: Literal[True],
-    ) -> Iterator[Tuple[str, Optional[StreamSeekBytesType], ObjectMeta]]:
+    ) -> Iterator[tuple[str, StreamSeekBytesType | None, ObjectMeta]]:
         ...
 
     def _get_objects_stream_meta_generator(  # pylint: disable=too-many-branches,too-many-statements,too-many-locals
@@ -540,10 +546,7 @@ class Container:  # pylint: disable=too-many-public-methods
         skip_if_missing: bool,
         with_streams: bool,
     ) -> Iterator[
-        Union[
-            Tuple[str, ObjectMeta],
-            Tuple[str, Optional[StreamSeekBytesType], ObjectMeta],
-        ]
+        (tuple[str, ObjectMeta] | tuple[str, StreamSeekBytesType | None, ObjectMeta])
     ]:
         """Return a generator yielding triplets of (hashkey, open stream, size).
 
@@ -570,12 +573,12 @@ class Container:  # pylint: disable=too-many-public-methods
         # open at a given time.
         # The try/finally block makes sure we close it at the end, if any was open.
         last_open_file = None
-        lazy_loose_stream: Optional[LazyLooseStream] = None
+        lazy_loose_stream: LazyLooseStream | None = None
 
         # Operate on a set - only return once per required hashkey, even if required more than once
         hashkeys_set = set(hashkeys)
 
-        hashkeys_in_packs: Set[str] = set()
+        hashkeys_in_packs: set[str] = set()
 
         packs = defaultdict(list)
         # Currently ordering in the DB (it's ordered across all packs, but this should not be
@@ -852,7 +855,7 @@ class Container:  # pylint: disable=too-many-public-methods
     @contextmanager
     def get_objects_stream_and_meta(
         self, hashkeys: Sequence[str], skip_if_missing: bool = True
-    ) -> Iterator[Iterator[Tuple[str, Optional[StreamSeekBytesType], ObjectMeta]]]:
+    ) -> Iterator[Iterator[tuple[str, StreamSeekBytesType | None, ObjectMeta]]]:
         """A context manager returning a generator yielding triplets of (hashkey, open stream, metadata).
 
         :note: the hash keys yielded are often in a *different* order than the original
@@ -894,7 +897,7 @@ class Container:  # pylint: disable=too-many-public-methods
 
     def get_objects_meta(
         self, hashkeys: Sequence[str], skip_if_missing: bool = True
-    ) -> Iterator[Tuple[str, ObjectMeta]]:
+    ) -> Iterator[tuple[str, ObjectMeta]]:
         """A generator yielding pairs of (hashkey, metadata).
 
         :note: the hash keys yielded are often in a *different* order than the original
@@ -959,7 +962,7 @@ class Container:  # pylint: disable=too-many-public-methods
         ), "No object found, this should never happen since I pass skip_if_missing=False!"
         raise NotExistent(f"No object with hash key {hashkey}")
 
-    def has_objects(self, hashkeys: Union[List[str], Tuple[str, ...]]) -> List[bool]:
+    def has_objects(self, hashkeys: list[str] | tuple[str, ...]) -> list[bool]:
         """Return whether the container contains objects with the given hash keys.
 
         :param hashkeys: a list of hash keys to check.
@@ -987,8 +990,8 @@ class Container:  # pylint: disable=too-many-public-methods
         return self.has_objects([hashkey])[0]
 
     def get_objects_content(
-        self, hashkeys: List[str], skip_if_missing: bool = True
-    ) -> Dict[str, Optional[bytes]]:
+        self, hashkeys: list[str], skip_if_missing: bool = True
+    ) -> dict[str, bytes | None]:
         """Get the content of a number of objects with given hash keys.
 
         :note: use this method only if you know objects fit in memory.
@@ -999,7 +1002,7 @@ class Container:  # pylint: disable=too-many-public-methods
         :return: a dictionary of byte streams where the keys are the hash keys and the values
             are the object contents.
         """
-        retrieved: Dict[str, Optional[bytes]] = {}
+        retrieved: dict[str, bytes | None] = {}
         with self.get_objects_stream_and_meta(
             hashkeys=hashkeys, skip_if_missing=skip_if_missing
         ) as triplets:
@@ -1260,8 +1263,8 @@ class Container:  # pylint: disable=too-many-public-methods
         pack_handle: StreamWriteBytesType,
         read_handle: StreamReadBytesType,
         compress: bool,
-        hash_type: Optional[str] = None,
-    ) -> Union[Tuple[int, None], Tuple[int, str]]:
+        hash_type: str | None = None,
+    ) -> tuple[int, None] | tuple[int, str]:
         """Append data, read from read_handle until it ends, to the correct packfile.
 
         Return the number of bytes READ (note that this will be different
@@ -1317,10 +1320,11 @@ class Container:  # pylint: disable=too-many-public-methods
 
     def pack_all_loose(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         self,
-        compress: Union[bool, CompressMode] = CompressMode.NO,
+        compress: bool | CompressMode = CompressMode.NO,
         validate_objects: bool = True,
         do_fsync: bool = True,
-        callback: Optional[Callable] = None,
+        callback: None
+        | (Callable[[Arg(str, "action"), Arg(Any, "value")], None]) = None,
     ) -> None:
         """Pack all loose objects.
 
@@ -1445,7 +1449,7 @@ class Container:  # pylint: disable=too-many-public-methods
                     # Get next hash key to process
                     loose_hashkey = loose_objects.pop()
 
-                    obj_dict: Dict[str, Any] = {}
+                    obj_dict: dict[str, Any] = {}
                     obj_dict["hashkey"] = loose_hashkey
                     obj_dict["pack_id"] = pack_int_id
                     obj_dict["offset"] = pack_handle.tell()
@@ -1541,7 +1545,7 @@ class Container:  # pylint: disable=too-many-public-methods
         open_streams: bool = False,
         no_holes: bool = False,
         no_holes_read_twice: bool = True,
-        callback: Optional[Callable] = None,
+        callback: Callable | None = None,
         callback_size_hint: int = 0,
         do_fsync: bool = True,
         do_commit: bool = True,
@@ -1555,7 +1559,7 @@ class Container:  # pylint: disable=too-many-public-methods
             length in the callbacks
         :return: a single object hash key
         """
-        streams: List[StreamSeekBytesType] = [
+        streams: list[StreamSeekBytesType] = [
             CallbackStreamWrapper(
                 stream, callback=callback, total_length=callback_size_hint
             )
@@ -1580,15 +1584,15 @@ class Container:  # pylint: disable=too-many-public-methods
 
     def add_streamed_objects_to_pack(  # pylint: disable=too-many-locals, too-many-branches, too-many-statements, too-many-arguments
         self,
-        stream_list: Union[List[StreamSeekBytesType], List[LazyOpener]],
+        stream_list: list[StreamSeekBytesType] | list[LazyOpener],
         compress: bool = False,
         open_streams: bool = False,
         no_holes: bool = False,
         no_holes_read_twice: bool = True,
-        callback: Optional[Callable] = None,
+        callback: Callable | None = None,
         do_fsync: bool = True,
         do_commit: bool = True,
-    ) -> List[str]:
+    ) -> list[str]:
         """Add objects directly to a pack, reading from a list of streams.
 
         This is a maintenance operation, available mostly for efficiency reasons
@@ -1628,7 +1632,7 @@ class Container:  # pylint: disable=too-many-public-methods
             compress, bool
         ), "Only True of False are valid `compress` modes when adding direclty to a pack"
         yield_per_size = 1000
-        hashkeys: List[str] = []
+        hashkeys: list[str] = []
 
         # Make a copy of the list and revert its order, so we can pop from the list
         # without affecting the original list, and it's from the end so it's fast
@@ -1742,7 +1746,7 @@ class Container:  # pylint: disable=too-many-public-methods
                     # is already there
                     position_before = pack_handle.tell()
 
-                    obj_dict: Dict[str, Any] = {}
+                    obj_dict: dict[str, Any] = {}
                     obj_dict["pack_id"] = pack_int_id
                     obj_dict["compressed"] = compress
                     obj_dict["offset"] = pack_handle.tell()
@@ -1877,14 +1881,14 @@ class Container:  # pylint: disable=too-many-public-methods
 
     def add_objects_to_pack(  # pylint: disable=too-many-arguments
         self,
-        content_list: Union[List[bytes], Tuple[bytes, ...]],
+        content_list: list[bytes] | tuple[bytes, ...],
         compress: bool = False,
         no_holes: bool = False,
         no_holes_read_twice: bool = True,
-        callback: Optional[Callable] = None,
+        callback: Callable | None = None,
         do_fsync: bool = True,
         do_commit: bool = True,
-    ) -> List[str]:
+    ) -> list[str]:
         """Add objects directly to a pack, reading from a list of content byte arrays.
 
         This is a maintenance operation, available mostly for efficiency reasons
@@ -1910,7 +1914,7 @@ class Container:  # pylint: disable=too-many-public-methods
 
         :return: a list of object hash keys
         """
-        stream_list: List[StreamSeekBytesType] = [
+        stream_list: list[StreamSeekBytesType] = [
             io.BytesIO(content) for content in content_list
         ]
         return self.add_streamed_objects_to_pack(
@@ -2104,12 +2108,12 @@ class Container:  # pylint: disable=too-many-public-methods
     def import_objects(  # pylint: disable=too-many-locals,too-many-statements,too-many-branches,too-many-arguments
         self,
         hashkeys: Sequence[str],
-        source_container: "Container",
+        source_container: Container,
         compress: bool = False,
         target_memory_bytes: int = 104857600,
-        callback: Optional[Callable] = None,
+        callback: Callable | None = None,
         do_fsync: bool = True,
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         """Imports the objects with the specified hashkeys into the container.
 
         :param hashkeys: an iterable of hash keys.
@@ -2132,7 +2136,7 @@ class Container:  # pylint: disable=too-many-public-methods
 
         # We load data in this cache as long as the memory usage is < target_memory_bytes
         # We then flush in 'bulk' to the `other_container`, thus speeding up the process
-        content_cache: Dict[str, bytes] = {}
+        content_cache: dict[str, bytes] = {}
         cache_size = 0
 
         if source_container.hash_type == self.hash_type:
@@ -2331,8 +2335,8 @@ class Container:  # pylint: disable=too-many-public-methods
 
     # Let us also compute the hash
     def _validate_hashkeys_pack(  # pylint: disable=too-many-locals
-        self, pack_id: int, callback: Optional[Callable] = None
-    ) -> Dict[str, Union[List[Union[str, Any]], List[Any]]]:
+        self, pack_id: int, callback: Callable | None = None
+    ) -> dict[str, list[str | Any] | list[Any]]:
         """Validate all hashkeys and returns a dictionary of problematic entries.
 
         The keys are the problem type, the values are a list of hashkeys of problematic objects.
@@ -2471,7 +2475,7 @@ class Container:  # pylint: disable=too-many-public-methods
             "overlapping_packed": overlapping,
         }
 
-    def validate(self, callback: Optional[Callable] = None) -> ValidationIssues:
+    def validate(self, callback: Callable | None = None) -> ValidationIssues:
         """Perform a number of validations on the container content, to make sure it is not corrupt.
 
         The callback can be used to show a progress bar (see e.g. its use in the `validate` command of
@@ -2482,7 +2486,7 @@ class Container:  # pylint: disable=too-many-public-methods
         dataclass to check if there are errors, or check all fields if you
         prefer and see if all fields are empty lists (which means no error).
         """
-        all_errors: Dict[str, List[str]] = {
+        all_errors: dict[str, list[str]] = {
             field.name: [] for field in dataclasses.fields(ValidationIssues)
         }
 
@@ -2520,7 +2524,7 @@ class Container:  # pylint: disable=too-many-public-methods
 
         return ValidationIssues(**dict(all_errors))
 
-    def delete_objects(self, hashkeys: List[str]) -> List[Union[str, Any]]:
+    def delete_objects(self, hashkeys: list[str]) -> list[str | Any]:
         """Delete the selected objects.
 
         .. note:: In the current version, this has to be considered a maintenance operation, and as such it should
@@ -2610,7 +2614,8 @@ class Container:  # pylint: disable=too-many-public-methods
     def repack(
         self,
         compress_mode: CompressMode = CompressMode.KEEP,
-        callback: Optional[Callable] = None,
+        callback: None
+        | (Callable[[Arg(str, "action"), Arg(Any, "value")], None]) = None,
     ) -> None:
         """Perform a repack of all packed objects.
 
@@ -2638,7 +2643,8 @@ class Container:  # pylint: disable=too-many-public-methods
         self,
         pack_id: str,
         compress_mode: CompressMode = CompressMode.KEEP,
-        callback: Optional[Callable] = None,
+        callback: None
+        | (Callable[[Arg(str, "action"), Arg(Any, "value")], None]) = None,
     ) -> None:
         """Perform a repack of a given pack object.
 
@@ -2715,9 +2721,9 @@ class Container:  # pylint: disable=too-many-public-methods
                     source_compressed,
                 ) in session.execute(stmt):
                     # This is the read handle of the bytes in the pack - it might be
-                    read_handle: Union[
-                        PackedObjectReader, ZlibStreamDecompresser
-                    ] = PackedObjectReader(read_pack, offset, length)
+                    read_handle: (
+                        PackedObjectReader | ZlibStreamDecompresser
+                    ) = PackedObjectReader(read_pack, offset, length)
 
                     # Determine if I should compress or not the destination - this function will
                     # try to do it in a cheap way (e.g. if the source is already compressed, will just

--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -1417,7 +1417,9 @@ class Container:  # pylint: disable=too-many-public-methods
                 },
             )
             # I wish this would show as MB, GB. In tqdm it's easy:
-            # just pass unit='B' and unit_scale=1024. But would callback accept **keywords?
+            # just pass unit='B' and unit_scale=1024.
+            # But to do this here, some changes is in callback function is needed.
+            # see this feature request for more details: https://github.com/aiidateam/aiida-core/issues/6564
 
         # Outer loop: this is used to continue when a new pack file needs to be created
         while loose_objects:

--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -1340,6 +1340,15 @@ class Container:  # pylint: disable=too-many-public-methods
             Needed to guarantee that data will be there even in the case of a power loss.
             Set to False if you don't need such a guarantee (anyway the loose version will be kept,
             so often this guarantee is not strictly needed).
+        :param callback: a callback function that can be used to report progress.
+            The callback function should accept two arguments: a string with the action being performed
+            and the value of the action. The action can be "init" (initialization),
+            "update" (update of the progress), or "close" (finalization).
+            In case of "init", the value is a dictionary with the key "total" as the total size of the operation
+            and key "description" as the label of the operation.
+            In case of "update", the value is amount of the operation that has been completed.
+            In case of "close", the value is None.
+            return value of the callback function is ignored.
         """
         hash_type = self.hash_type if validate_objects else None
 
@@ -2611,6 +2620,15 @@ class Container:  # pylint: disable=too-many-public-methods
         This is a maintenance operation.
 
         :param compress_mode: see docstring of ``repack_pack``.
+        :param callback: a callback function that can be used to report progress.
+            The callback function should accept two arguments: a string with the action being performed
+            and the value of the action. The action can be "init" (initialization),
+            "update" (update of the progress), or "close" (finalization).
+            In case of "init", the value is a dictionary with the key "total" as the total size of the operation
+            and key "description" as the label of the operation.
+            In case of "update", the value is amount of the operation that has been completed.
+            In case of "close", the value is None.
+            return value of the callback function is ignored.
         """
         for pack_id in self._list_packs():
             self.repack_pack(pack_id, compress_mode=compress_mode, callback=callback)
@@ -2631,6 +2649,15 @@ class Container:  # pylint: disable=too-many-public-methods
             preserves the same compression (this means that repacking is *much* faster
             as it can simply transfer the bytes without decompressing everything first,
             and recompressing it back again).
+        :param callback: a callback function that can be used to report progress.
+            The callback function should accept two arguments: a string with the action being performed
+            and the value of the action. The action can be "init" (initialization),
+            "update" (update of the progress), or "close" (finalization).
+            In case of "init", the value is a dictionary with the key "total" as the total size of the operation
+            and key "description" as the label of the operation.
+            In case of "update", the value is amount of the operation that has been completed.
+            In case of "close", the value is None.
+            return value of the callback function is ignored.
         """
         assert (
             pack_id != self._REPACK_PACK_ID


### PR DESCRIPTION
Suggested by @giovannipizzi:
Currently, `verdi storage maintain` in `aiida-core` might take a long time to proceed, and many users might not be patient enough, and they may cancel the progress just very close to the end. It's nice to provide an estimated time so they will have an idea of how long this would take. 
To implement it, I followed these steps: 
1) `verdi storage maintain` calls [here](https://github.com/aiidateam/aiida-core/blob/c3cc169c487a88e2357b7377e897f0521c23f05a/src/aiida/repository/backend/disk_object_store.py#L148) in the disk object store backend
2) which would possibly call either of these three methods: a) `pack_all_loose` b) `repack` c) `clean_storage`
3) I made a small container (300MB, ~600 files) and ran `cProfile` to look for the time-consuming parts and inserted "update" in the relevant positions:
    - `pack_all_loose`: the iterations over `loose_objects`
    - `repack`: mostly the iteration, but also `safe_flush_to_disk` which calls `os.fsync`, there is no easy way to predict time consumed on that, so I just ignore it, which means the maintenance will still go on a bit even after the bar reaches 100%. 
    - `clean_storage`:  was very quick for the mentioned size of container—just a few milliseconds—so I trusted the scalability and skipped adding a bar for this method.

Once this is approved, I can make another PR on `aiida-core` to pass a progress bar to these.
