### PR TITLE
Update to `setup-python@v5`

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - name: Install dependencies (including dev dependencies at frozen version)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.8"
       - uses: pre-commit/action@v2.0.0
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
         # Set up 'ssh localhost' that is used in testing the backup command

--- a/.github/workflows/concurrency.yml
+++ b/.github/workflows/concurrency.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies (including dev dependencies at frozen version)

--- a/requirements.lock
+++ b/requirements.lock
@@ -58,7 +58,7 @@ pytest-benchmark==4.0.0
     # via disk-objectstore (setup.py)
 pytest-cov==4.1.0
     # via disk-objectstore (setup.py)
-pyyaml==6.0
+pyyaml==6.0.1
     # via pre-commit
 sqlalchemy==1.4.48
     # via disk-objectstore (setup.py)


### PR DESCRIPTION
`actions/setup-python@v2` is deprecated and currently is causing continuous integration test fail for macos. 
This will fix for macos with python 3.9,3.10, and 3.11. 
`macos && python 3.8` is still [failing](https://github.com/khsrali/disk-objectstore/actions/runs/9174022904/job/25223976134) for different reasons: that apparently `cython` dependency is not properly installed, which I don't understand why. But that is independent of this fix. (used to fail even with `setup-python@v1`)