### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.2.0 (26 September 2024)
+
+This only enforces proper semantic versioning as the last release added a new functionality. No changes have been added.
+
 ## v1.1.1 (19 September 2024)
 
 - Added progress bar functionality for repack and pack_all_loose [\[737f9c7\]](https://github.com/aiidateam/disk-objectstore/commit/737f9c71151bf7ac297c6431688b4a75eac91b7c)

--- a/disk_objectstore/__init__.py
+++ b/disk_objectstore/__init__.py
@@ -11,4 +11,4 @@ LOGGER = logging.getLogger(__name__)
 
 __all__ = ("Container", "ObjectType", "CompressMode")
 
-__version__ = "1.1.1"
+__version__ = "1.2.0"


### PR DESCRIPTION
This only enforces proper semantic versioning as the last release added a new functionality and should updating the minor not patch. No changes have been added.