### PR TITLE
Close container on deletion

### DIFF
--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -167,6 +167,10 @@ class Container:  # pylint: disable=too-many-public-methods
         """Close the session when exiting the context."""
         self.close()
 
+    def __del__(self) -> None:
+        """Closes all connections on deletion."""
+        self.close()
+
     def _get_sandbox_folder(self) -> Path:
         """Return the path to the sandbox folder that is used during a new object creation.
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1197,7 +1197,7 @@ def test_get_objects_stream_closes(temp_dir, generate_random_data):
             obj_md5s.keys(), skip_if_missing=True
         ) as triplets:
             # I loop over the triplets, but I don't do anything
-            for _ in triplets:
+            for _ in triplets:  # pylint: disable=not-an-iterable
                 assert len(current_process.open_files()) <= start_open_files + 1
 
         # Check that at the end nothing is left open
@@ -1208,7 +1208,7 @@ def test_get_objects_stream_closes(temp_dir, generate_random_data):
             obj_md5s.keys(), skip_if_missing=True
         ) as triplets:
             # I loop over the triplets, but I don't do anything
-            for _, stream, _ in triplets:
+            for _, stream, _ in triplets:  # pylint: disable=not-an-iterable
                 assert len(current_process.open_files()) <= start_open_files + 1
                 stream.read()
 
@@ -1233,7 +1233,7 @@ def test_get_objects_stream_closes(temp_dir, generate_random_data):
 
         with temp_container.get_objects_stream_and_meta(obj_md5s.keys()) as triplets:
             # I loop over the triplets, but I don't do anything
-            for _ in triplets:
+            for _ in triplets:  # pylint: disable=not-an-iterable
                 assert len(current_process.open_files()) <= start_open_files + 1
 
         # Check that at the end nothing is left open
@@ -1244,7 +1244,7 @@ def test_get_objects_stream_closes(temp_dir, generate_random_data):
             obj_md5s.keys(), skip_if_missing=True
         ) as triplets:
             # I loop over the triplets, but I don't do anything
-            for _, stream, _ in triplets:
+            for _, stream, _ in triplets:  # pylint: disable=not-an-iterable
                 assert len(current_process.open_files()) <= start_open_files + 1
                 stream.read()
         # Check that at the end nothing is left open
@@ -1273,7 +1273,7 @@ def test_get_objects_stream_closes(temp_dir, generate_random_data):
 
         with temp_container.get_objects_stream_and_meta(obj_md5s.keys()) as triplets:
             # I loop over the triplets, but I don't do anything
-            for _ in triplets:
+            for _ in triplets:  # pylint: disable=not-an-iterable
                 assert len(current_process.open_files()) <= start_open_files + 1
 
         # Check that at the end nothing is left open
@@ -1284,7 +1284,7 @@ def test_get_objects_stream_closes(temp_dir, generate_random_data):
             obj_md5s.keys(), skip_if_missing=True
         ) as triplets:
             # I loop over the triplets, but I don't do anything
-            for _, stream, _ in triplets:
+            for _, stream, _ in triplets:  # pylint: disable=not-an-iterable
                 assert len(current_process.open_files()) <= start_open_files + 1
                 stream.read()
         # Check that at the end nothing is left open


### PR DESCRIPTION
In case the container is not used within a context and not correctly closed. The sessions are still correctly closed if the container is picked up by the garbage collection.