### PR TITLE
Close session in meta generator

### DIFF
--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -145,7 +145,6 @@ class Container:  # pylint: disable=too-many-public-methods
             if isinstance(binding, Engine):
                 binding.dispose()
             elif isinstance(binding, Connection):
-                binding.invalidate()
                 binding.close()
             self._operation_session = None
 
@@ -155,7 +154,6 @@ class Container:  # pylint: disable=too-many-public-methods
             if isinstance(binding, Engine):
                 binding.dispose()
             elif isinstance(binding, Connection):
-                binding.invalidate()
                 binding.close()
             self._container_session = None
 
@@ -756,7 +754,6 @@ class Container:  # pylint: disable=too-many-public-methods
                 if isinstance(binding, Engine):
                     binding.dispose()
                 elif isinstance(binding, Connection):
-                    binding.invalidate()
                     binding.close()
                 self._operation_session = None
 

--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -749,8 +749,15 @@ class Container:  # pylint: disable=too-many-public-methods
             # Note that this is an expensive operation!
             # This means that asking for non-existing objects will be
             # slow.
+
             if self._operation_session is not None:
+                binding = self._operation_session.bind
                 self._operation_session.close()
+                if isinstance(binding, Engine):
+                    binding.dispose()
+                elif isinstance(binding, Connection):
+                    binding.invalidate()
+                    binding.close()
                 self._operation_session = None
 
             packs = defaultdict(list)

--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -137,8 +137,7 @@ class Container:  # pylint: disable=too-many-public-methods
         """Return the path to the folder that will host the object-store container."""
         return self._folder
 
-    def close(self) -> None:
-        """Close open files (in particular, the connection to the SQLite DB)."""
+    def _close_operation_session(self):
         if self._operation_session is not None:
             binding = self._operation_session.bind
             self._operation_session.close()
@@ -147,6 +146,10 @@ class Container:  # pylint: disable=too-many-public-methods
             elif isinstance(binding, Connection):
                 binding.close()
             self._operation_session = None
+
+    def close(self) -> None:
+        """Close open files (in particular, the connection to the SQLite DB)."""
+        self._close_operation_session()
 
         if self._container_session is not None:
             binding = self._container_session.bind
@@ -747,15 +750,7 @@ class Container:  # pylint: disable=too-many-public-methods
             # Note that this is an expensive operation!
             # This means that asking for non-existing objects will be
             # slow.
-
-            if self._operation_session is not None:
-                binding = self._operation_session.bind
-                self._operation_session.close()
-                if isinstance(binding, Engine):
-                    binding.dispose()
-                elif isinstance(binding, Connection):
-                    binding.close()
-                self._operation_session = None
+            self._close_operation_session()
 
             packs = defaultdict(list)
             session = self._get_operation_session()


### PR DESCRIPTION
The issue was the in an internal function the session was closed but the session pool was not disposed. This bug was already present before starting the session fixes. It became apparent due to some upstream package update. I did not faithfully transferred the `requirements.lock` to `uv.lock` thus some package was update thus this bug became apparent.  You can see in [this CI run](https://github.com/aiidateam/disk-objectstore/actions/runs/13964976594) not containing the fix but faithfully using the  `requirements.lock ` that it does not fail. The first commit contains the fix and I added some cleaning up and mini refactoring in the second and third commit.