### PR TITLE
Replace pylint and black with ruff

### DIFF
--- a/.github/workflows/check_release_tag.py
+++ b/.github/workflows/check_release_tag.py
@@ -1,19 +1,20 @@
 """Check that the GitHub release tag matches the package version."""
+
 import argparse
 import pathlib
 import re
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument("GITHUB_REF", help="The GITHUB_REF environmental variable")
-    parser.add_argument("INIT_PATH", help="Path to the init file")
+    parser.add_argument('GITHUB_REF', help='The GITHUB_REF environmental variable')
+    parser.add_argument('INIT_PATH', help='Path to the init file')
     args = parser.parse_args()
     assert args.GITHUB_REF.startswith(
-        "refs/tags/v"
+        'refs/tags/v'
     ), f'GITHUB_REF should start with "refs/tags/v": {args.GITHUB_REF}'
     tag_version = args.GITHUB_REF[11:]
-    data = pathlib.Path(args.INIT_PATH).read_text("utf8")
+    data = pathlib.Path(args.INIT_PATH).read_text('utf8')
     pypi_version = re.search(r"__version__ = ['\"](.*?)['\"]", data).group(1)
     assert (
         tag_version == pypi_version
-    ), f"The tag version {tag_version} != {pypi_version} specified in {args.INIT_PATH}"
+    ), f'The tag version {tag_version} != {pypi_version} specified in {args.INIT_PATH}'

--- a/.github/workflows/check_release_tag.py
+++ b/.github/workflows/check_release_tag.py
@@ -9,12 +9,8 @@ if __name__ == '__main__':
     parser.add_argument('GITHUB_REF', help='The GITHUB_REF environmental variable')
     parser.add_argument('INIT_PATH', help='Path to the init file')
     args = parser.parse_args()
-    assert args.GITHUB_REF.startswith(
-        'refs/tags/v'
-    ), f'GITHUB_REF should start with "refs/tags/v": {args.GITHUB_REF}'
+    assert args.GITHUB_REF.startswith('refs/tags/v'), f'GITHUB_REF should start with "refs/tags/v": {args.GITHUB_REF}'
     tag_version = args.GITHUB_REF[11:]
     data = pathlib.Path(args.INIT_PATH).read_text('utf8')
     pypi_version = re.search(r"__version__ = ['\"](.*?)['\"]", data).group(1)
-    assert (
-        tag_version == pypi_version
-    ), f'The tag version {tag_version} != {pypi_version} specified in {args.INIT_PATH}'
+    assert tag_version == pypi_version, f'The tag version {tag_version} != {pypi_version} specified in {args.INIT_PATH}'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,35 +33,18 @@ repos:
       - mdformat-black
       files: (?x)^(README\.md|CHANGELOG\.md)$
 
-  - repo: https://github.com/pycqa/isort
-    rev: '5.12.0'
-    hooks:
-    - id: isort
-
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.14.0
     hooks:
     - id: pyupgrade
       args: [--py37-plus]
 
-  - repo: https://github.com/psf/black
-    rev: '23.9.1'
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.6
     hooks:
-    - id: black
-
-  - repo: https://github.com/PyCQA/pylint
-    rev: v3.0.0
-    hooks:
-    - id: pylint
-      additional_dependencies:
-      - sqlalchemy==1.4.22
-      - click==8.0.1
-      - memory-profiler==0.58.0
-      - profilehooks==1.12.0
-      - psutil==5.8.0
-      - pytest==6.2.4
-      - numpy
-      - h5py
+    - id: ruff-format
+    - id: ruff
+      args: [--fix, --exit-non-zero-on-fix, --show-fixes]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.5.1

--- a/disk_objectstore/__init__.py
+++ b/disk_objectstore/__init__.py
@@ -9,6 +9,6 @@ from .container import CompressMode, Container, ObjectType
 
 LOGGER = logging.getLogger(__name__)
 
-__all__ = ("Container", "ObjectType", "CompressMode")
+__all__ = ('CompressMode', 'Container', 'ObjectType')
 
-__version__ = "1.2.0"
+__version__ = '1.2.0'

--- a/disk_objectstore/backup_utils.py
+++ b/disk_objectstore/backup_utils.py
@@ -61,24 +61,18 @@ class BackupManager:
         # Validate the backup config inputs
 
         if self.keep is not None and self.keep < 0:
-            raise ValueError(
-                "Input validation failed: keep variable can't be negative!"
-            )
+            raise ValueError("Input validation failed: keep variable can't be negative!")
 
         if self.remote:
             self.check_if_remote_accessible()
 
         if not is_exe_found(self.rsync_exe):
-            raise ValueError(
-                f'Input validation failed: {self.rsync_exe} not accessible.'
-            )
+            raise ValueError(f'Input validation failed: {self.rsync_exe} not accessible.')
 
         if not self.check_path_exists(self.path):
             success = self.run_cmd(['mkdir', str(self.path)])[0]
             if not success:
-                raise ValueError(
-                    f"Input validation failed: Couldn't access/create '{self.path!s}'!"
-                )
+                raise ValueError(f"Input validation failed: Couldn't access/create '{self.path!s}'!")
 
         self.rsync_version = self.get_rsync_major_version()
 
@@ -202,9 +196,7 @@ class BackupManager:
         cmd_str = ' '.join(all_args)
         LOGGER.info("Running '%s'", cmd_str)
 
-        res = subprocess.run(
-            all_args, capture_output=capture_output, text=True, check=False
-        )
+        res = subprocess.run(all_args, capture_output=capture_output, text=True, check=False)
 
         info_text = f'rsync completed. Exit Code: {res.returncode}'
         if capture_output:
@@ -276,9 +268,7 @@ class BackupManager:
         last_folder = self.get_last_backup_folder()
 
         if last_folder:
-            LOGGER.info(
-                "Last backup is '%s', using it for rsync --link-dest.", str(last_folder)
-            )
+            LOGGER.info("Last backup is '%s', using it for rsync --link-dest.", str(last_folder))
         else:
             LOGGER.info("Couldn't find a previous backup to increment from.")
 
@@ -288,19 +278,13 @@ class BackupManager:
         )
 
         # move live-backup -> backup_<timestamp>_<randstr>
-        timestamp = datetime.datetime.now(datetime.timezone.utc).strftime(
-            '%Y%m%d%H%M%S'
-        )
+        timestamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%d%H%M%S')
         randstr = ''.join(random.choices(string.ascii_lowercase + string.digits, k=4))
         folder_name = f'backup_{timestamp}_{randstr}'
 
-        success = self.run_cmd(['mv', str(live_folder), str(self.path / folder_name)])[
-            0
-        ]
+        success = self.run_cmd(['mv', str(live_folder), str(self.path / folder_name)])[0]
         if not success:
-            raise BackupError(
-                f"Failed to move '{live_folder!s}' to '{self.path / folder_name!s}'"
-            )
+            raise BackupError(f"Failed to move '{live_folder!s}' to '{self.path / folder_name!s}'")
 
         LOGGER.info(
             "Backup moved from '%s' to '%s'.",
@@ -309,9 +293,7 @@ class BackupManager:
         )
 
         symlink_name = 'last-backup'
-        success = self.run_cmd(
-            ['ln', '-sfn', str(folder_name), str(self.path / symlink_name)]
-        )[0]
+        success = self.run_cmd(['ln', '-sfn', str(folder_name), str(self.path / symlink_name)])[0]
         if not success:
             LOGGER.warning(
                 "Couldn't create symlink '%s'. Perhaps the filesystem doesn't support it.",

--- a/disk_objectstore/backup_utils.py
+++ b/disk_objectstore/backup_utils.py
@@ -26,13 +26,13 @@ class BackupError(Exception):
 
 def split_remote_and_path(dest: str):
     """extract remote and path from <remote>:<path>"""
-    split_dest = dest.split(":")
+    split_dest = dest.split(':')
     if len(split_dest) == 1:
         return None, Path(dest)
     if len(split_dest) == 2:
         return split_dest[0], Path(split_dest[1])
     # more than 1 colon:
-    raise ValueError("Invalid destination format: <remote>:<path>")
+    raise ValueError('Invalid destination format: <remote>:<path>')
 
 
 def is_exe_found(exe: str) -> bool:
@@ -56,7 +56,7 @@ class BackupManager:
         self.dest = dest
         self.keep = keep
         self.remote, self.path = split_remote_and_path(dest)
-        self.rsync_exe = rsync_exe if rsync_exe is not None else "rsync"
+        self.rsync_exe = rsync_exe if rsync_exe is not None else 'rsync'
 
         # Validate the backup config inputs
 
@@ -70,14 +70,14 @@ class BackupManager:
 
         if not is_exe_found(self.rsync_exe):
             raise ValueError(
-                f"Input validation failed: {self.rsync_exe} not accessible."
+                f'Input validation failed: {self.rsync_exe} not accessible.'
             )
 
         if not self.check_path_exists(self.path):
-            success = self.run_cmd(["mkdir", str(self.path)])[0]
+            success = self.run_cmd(['mkdir', str(self.path)])[0]
             if not success:
                 raise ValueError(
-                    f"Input validation failed: Couldn't access/create '{str(self.path)}'!"
+                    f"Input validation failed: Couldn't access/create '{self.path!s}'!"
                 )
 
         self.rsync_version = self.get_rsync_major_version()
@@ -85,13 +85,13 @@ class BackupManager:
     def check_if_remote_accessible(self):
         """Check if remote host is accessible via ssh"""
         LOGGER.info("Checking if '%s' is accessible...", self.remote)
-        success = self.run_cmd(["exit"])[0]
+        success = self.run_cmd(['exit'])[0]
         if not success:
             raise BackupError(f"Remote '{self.remote}' is not accessible!")
         LOGGER.info("Success! '%s' is accessible!", self.remote)
 
     def check_path_exists(self, path: Path) -> bool:
-        cmd = ["[", "-e", str(path), "]"]
+        cmd = ['[', '-e', str(path), ']']
         return self.run_cmd(cmd)[0]
 
     def run_cmd(
@@ -103,12 +103,12 @@ class BackupManager:
         """
         all_args = args[:]
         if self.remote:
-            all_args = ["ssh", self.remote] + all_args
+            all_args = ['ssh', self.remote] + all_args
 
         res = subprocess.run(all_args, capture_output=True, text=True, check=False)
 
         LOGGER.debug(
-            "Command: %s\n  Exit Code: %d\n  stdout/stderr: %s\n%s",
+            'Command: %s\n  Exit Code: %d\n  stdout/stderr: %s\n%s',
             str(all_args),
             res.returncode,
             res.stdout,
@@ -124,15 +124,15 @@ class BackupManager:
         Get the rsync major version.
         """
         result = subprocess.run(
-            [self.rsync_exe, "--version"],
+            [self.rsync_exe, '--version'],
             capture_output=True,
             text=True,
             check=False,
         )
-        pattern = r"rsync\s+version\s+(\d+\.\d+\.\d+)"
+        pattern = r'rsync\s+version\s+(\d+\.\d+\.\d+)'
         match = re.search(pattern, result.stdout)
         if match:
-            return int(match.group(1).split(".")[0])
+            return int(match.group(1).split('.')[0])
         return None
 
     def call_rsync(  # pylint: disable=too-many-arguments,too-many-branches
@@ -160,8 +160,8 @@ class BackupManager:
 
         all_args = [
             self.rsync_exe,
-            "-azh",
-            "--no-whole-file",
+            '-azh',
+            '--no-whole-file',
         ]
 
         capture_output = True
@@ -170,49 +170,49 @@ class BackupManager:
             if self.rsync_version and self.rsync_version >= 3:
                 # These options show progress in a nicer way but
                 # they're only available for rsync version 3+
-                all_args += ["--info=progress2,stats1"]
+                all_args += ['--info=progress2,stats1']
             else:
                 LOGGER.info("rsync version <3 detected: showing 'legacy' progress.")
-                all_args += ["--progress"]
+                all_args += ['--progress']
 
         if LOGGER.isEnabledFor(logging.DEBUG):
-            all_args += ["-vv"]
+            all_args += ['-vv']
         if extra_args:
             all_args += extra_args
         if link_dest:
             if not self.remote:
                 # for local paths, use resolve() to get absolute path
                 link_dest = link_dest.resolve()
-            all_args += [f"--link-dest={link_dest}"]
+            all_args += [f'--link-dest={link_dest}']
 
         if src_trailing_slash:
-            all_args += [str(src) + "/"]
+            all_args += [str(src) + '/']
         else:
             all_args += [str(src)]
 
         dest_str = str(dest)
         if dest_trailing_slash:
-            dest_str += "/"
+            dest_str += '/'
 
         if not self.remote:
             all_args += [dest_str]
         else:
-            all_args += [f"{self.remote}:{dest_str}"]
+            all_args += [f'{self.remote}:{dest_str}']
 
-        cmd_str = " ".join(all_args)
+        cmd_str = ' '.join(all_args)
         LOGGER.info("Running '%s'", cmd_str)
 
         res = subprocess.run(
             all_args, capture_output=capture_output, text=True, check=False
         )
 
-        info_text = f"rsync completed. Exit Code: {res.returncode}"
+        info_text = f'rsync completed. Exit Code: {res.returncode}'
         if capture_output:
-            info_text += f"\nstdout/stderr: {res.stdout}\n{res.stderr}"
+            info_text += f'\nstdout/stderr: {res.stdout}\n{res.stderr}'
         LOGGER.info(info_text)
 
         if res.returncode != 0:
-            raise BackupError(f"rsync failed for: {str(src)} to {str(dest)}")
+            raise BackupError(f'rsync failed for: {src!s} to {dest!s}')
 
     # ----
     # Utilities to manage multiple folders of backups, e.g. hard-linking to previous backup;
@@ -223,20 +223,20 @@ class BackupManager:
         """Get all folders matching the backup folder name pattern."""
         success, stdout = self.run_cmd(
             [
-                "find",
+                'find',
                 str(self.path),
-                "-maxdepth",
-                "1",
-                "-type",
-                "d",
-                "-name",
-                "backup_*_*",
-                "-print",
+                '-maxdepth',
+                '1',
+                '-type',
+                'd',
+                '-name',
+                'backup_*_*',
+                '-print',
             ]
         )
 
         if not success:
-            raise BackupError("Existing backups determination failed.")
+            raise BackupError('Existing backups determination failed.')
 
         return stdout.splitlines()
 
@@ -251,9 +251,9 @@ class BackupManager:
             sorted_folders = sorted(self.get_existing_backup_folders())
             to_delete = sorted_folders[: -(self.keep + 1)]
             for folder in to_delete:
-                success = self.run_cmd(["rm", "-rf", folder])[0]
+                success = self.run_cmd(['rm', '-rf', folder])[0]
                 if success:
-                    LOGGER.info("Deleted old backup: %s", folder)
+                    LOGGER.info('Deleted old backup: %s', folder)
                 else:
                     LOGGER.warning("Warning: couldn't delete old backup: %s", folder)
 
@@ -271,7 +271,7 @@ class BackupManager:
 
         """
 
-        live_folder = self.path / "live-backup"
+        live_folder = self.path / 'live-backup'
 
         last_folder = self.get_last_backup_folder()
 
@@ -289,17 +289,17 @@ class BackupManager:
 
         # move live-backup -> backup_<timestamp>_<randstr>
         timestamp = datetime.datetime.now(datetime.timezone.utc).strftime(
-            "%Y%m%d%H%M%S"
+            '%Y%m%d%H%M%S'
         )
-        randstr = "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
-        folder_name = f"backup_{timestamp}_{randstr}"
+        randstr = ''.join(random.choices(string.ascii_lowercase + string.digits, k=4))
+        folder_name = f'backup_{timestamp}_{randstr}'
 
-        success = self.run_cmd(["mv", str(live_folder), str(self.path / folder_name)])[
+        success = self.run_cmd(['mv', str(live_folder), str(self.path / folder_name)])[
             0
         ]
         if not success:
             raise BackupError(
-                f"Failed to move '{str(live_folder)}' to '{str(self.path / folder_name)}'"
+                f"Failed to move '{live_folder!s}' to '{self.path / folder_name!s}'"
             )
 
         LOGGER.info(
@@ -308,9 +308,9 @@ class BackupManager:
             str(self.path / folder_name),
         )
 
-        symlink_name = "last-backup"
+        symlink_name = 'last-backup'
         success = self.run_cmd(
-            ["ln", "-sfn", str(folder_name), str(self.path / symlink_name)]
+            ['ln', '-sfn', str(folder_name), str(self.path / symlink_name)]
         )[0]
         if not success:
             LOGGER.warning(
@@ -363,28 +363,28 @@ def backup_container(
     prev_backup_loose = prev_backup / loose_path_rel if prev_backup else None
 
     manager.call_rsync(loose_path, path, link_dest=prev_backup_loose)
-    LOGGER.info("Transferred %s to %s", str(loose_path), str(path))
+    LOGGER.info('Transferred %s to %s', str(loose_path), str(path))
 
     # step 2: back up sqlite db
 
     # make a temporary directory to dump sqlite db locally
     with tempfile.TemporaryDirectory() as temp_dir_name:
-        sqlite_temp_loc = Path(temp_dir_name) / "packs.idx"
+        sqlite_temp_loc = Path(temp_dir_name) / 'packs.idx'
         _sqlite_backup(sqlite_path, sqlite_temp_loc)
 
         if sqlite_temp_loc.is_file():
-            LOGGER.info("Dumped the SQLite database to %s", str(sqlite_temp_loc))
+            LOGGER.info('Dumped the SQLite database to %s', str(sqlite_temp_loc))
         else:
-            raise BackupError(f"'{str(sqlite_temp_loc)}' failed to be created.")
+            raise BackupError(f"'{sqlite_temp_loc!s}' failed to be created.")
 
         # step 3: transfer the SQLITE database file
         manager.call_rsync(sqlite_temp_loc, path, link_dest=prev_backup)
-        LOGGER.info("Transferred SQLite database to %s", str(path))
+        LOGGER.info('Transferred SQLite database to %s', str(path))
 
     # step 4: transfer the packed files
     packs_path_rel = packs_path.relative_to(container_root_path)
     manager.call_rsync(packs_path, path, link_dest=prev_backup)
-    LOGGER.info("Transferred %s to %s", str(packs_path), str(path))
+    LOGGER.info('Transferred %s to %s', str(packs_path), str(path))
 
     # step 5: transfer anything else in the container folder
     manager.call_rsync(
@@ -393,11 +393,11 @@ def backup_container(
         link_dest=prev_backup,
         src_trailing_slash=True,
         extra_args=[
-            "--exclude",
+            '--exclude',
             str(loose_path_rel),
-            "--exclude",
-            "packs.idx",
-            "--exclude",
+            '--exclude',
+            'packs.idx',
+            '--exclude',
             str(packs_path_rel),
         ],
     )

--- a/disk_objectstore/cli.py
+++ b/disk_objectstore/cli.py
@@ -29,9 +29,7 @@ class ContainerContext:
     def container(self) -> Container:
         """Get the container, creating if it does not exist."""
         if not self.path.exists():
-            raise click.ClickException(
-                f'Container does not exist (run create command): {self.path}'
-            )
+            raise click.ClickException(f'Container does not exist (run create command): {self.path}')
         return Container(str(self.path))
 
 
@@ -54,9 +52,7 @@ def main(ctx, path):
 
 
 @main.command('create')
-@click.option(
-    '-a', '--algorithm', default='zlib+1', help='Compression algorithm to use'
-)
+@click.option('-a', '--algorithm', default='zlib+1', help='Compression algorithm to use')
 @pass_dostore
 def create(dostore: ContainerContext, algorithm: str):
     """Create a container"""
@@ -106,9 +102,7 @@ def validate(dostore: ContainerContext, verbose: bool):
                 if action == 'init':
                     if self.progress_bar is not None:
                         self.progress_bar.close()  # pragma: no cover
-                    self.progress_bar = tqdm.tqdm(
-                        total=value['total'], desc=value['description']
-                    )
+                    self.progress_bar = tqdm.tqdm(total=value['total'], desc=value['description'])
                 elif action == 'update':
                     value = value or 1  # If 0 or None
                     if self.progress_bar is None:
@@ -151,9 +145,7 @@ def validate(dostore: ContainerContext, verbose: bool):
 def add_files(dostore: ContainerContext, files: List[str]):
     """Add file(s) to the container"""
     with dostore.container as container:
-        click.echo(
-            f'Adding {len(files)} file(s) to container: {container.get_folder()}'
-        )
+        click.echo(f'Adding {len(files)} file(s) to container: {container.get_folder()}')
         for filepath in files:
             with open(filepath, 'rb') as fobj:
                 hashkey = container.add_streamed_object(fobj)
@@ -168,13 +160,9 @@ def add_files(dostore: ContainerContext, files: List[str]):
     show_default=True,
     help='Compress objects before storing',
 )
-@click.option(
-    '--vacuum/--no-vacuum', default=True, show_default=True, help='Vacuum the database'
-)
+@click.option('--vacuum/--no-vacuum', default=True, show_default=True, help='Vacuum the database')
 @pass_dostore
-def optimize(
-    dostore: ContainerContext, non_interactive: bool, compress: bool, vacuum: bool
-):
+def optimize(dostore: ContainerContext, non_interactive: bool, compress: bool, vacuum: bool):
     """Optimize the container's memory use"""
     if not non_interactive:
         click.confirm('Is this the only process accessing the container?', abort=True)
@@ -207,9 +195,7 @@ def optimize(
     help='Set verbosity of the logger.',
 )
 @pass_dostore
-def backup(
-    dostore: ContainerContext, dest: str, keep: int, rsync_exe: str, verbosity: str
-):
+def backup(dostore: ContainerContext, dest: str, keep: int, rsync_exe: str, verbosity: str):
     """Create a backup of the container.
 
     The backup is created at the `DEST` destination, in a subfolder
@@ -251,9 +237,7 @@ def backup(
                 rsync_exe=rsync_exe,
             )
             backup_manager.backup_auto_folders(
-                lambda path, prev: backup_utils.backup_container(
-                    backup_manager, container, path, prev
-                )
+                lambda path, prev: backup_utils.backup_container(backup_manager, container, path, prev)
             )
         except (ValueError, backup_utils.BackupError) as e:
             click.echo(f'Error: {e}')

--- a/disk_objectstore/cli.py
+++ b/disk_objectstore/cli.py
@@ -30,7 +30,7 @@ class ContainerContext:
         """Get the container, creating if it does not exist."""
         if not self.path.exists():
             raise click.ClickException(
-                f"Container does not exist (run create command): {self.path}"
+                f'Container does not exist (run create command): {self.path}'
             )
         return Container(str(self.path))
 
@@ -38,14 +38,14 @@ class ContainerContext:
 pass_dostore = click.make_pass_decorator(ContainerContext)
 
 
-@click.group(context_settings={"help_option_names": ["--help"]})
+@click.group(context_settings={'help_option_names': ['--help']})
 @click.version_option(__version__)
 @click.option(
-    "-p",
-    "--path",
-    default=os.environ.get("DOSTORE_PATH", str(Path.cwd().joinpath("dostore"))),
+    '-p',
+    '--path',
+    default=os.environ.get('DOSTORE_PATH', str(Path.cwd().joinpath('dostore'))),
     show_default=True,
-    help="Path to the container (or set env DOSTORE_PATH)",
+    help='Path to the container (or set env DOSTORE_PATH)',
 )
 @click.pass_context
 def main(ctx, path):
@@ -53,39 +53,39 @@ def main(ctx, path):
     ctx.obj = ContainerContext(path)
 
 
-@main.command("create")
+@main.command('create')
 @click.option(
-    "-a", "--algorithm", default="zlib+1", help="Compression algorithm to use"
+    '-a', '--algorithm', default='zlib+1', help='Compression algorithm to use'
 )
 @pass_dostore
 def create(dostore: ContainerContext, algorithm: str):
     """Create a container"""
     if dostore.path.exists():
-        raise click.ClickException(f"Container already exists: {dostore.path}")
+        raise click.ClickException(f'Container already exists: {dostore.path}')
     container = Container(str(dostore.path))
     container.init_container(compression_algorithm=algorithm)
-    click.echo(f"Created container: {container.get_folder()}")
+    click.echo(f'Created container: {container.get_folder()}')
 
 
-@main.command("status")
+@main.command('status')
 @pass_dostore
 def status(dostore: ContainerContext):
     """Print details about the container"""
     with dostore.container as container:
-        data: dict = {"path": str(container.get_folder())}
-        data["id"] = container.container_id
-        data["compression"] = container.compression_algorithm
-        data["count"] = dataclasses.asdict(container.count_objects())
-        data["size"] = dataclasses.asdict(container.get_total_size())
+        data: dict = {'path': str(container.get_folder())}
+        data['id'] = container.container_id
+        data['compression'] = container.compression_algorithm
+        data['count'] = dataclasses.asdict(container.count_objects())
+        data['size'] = dataclasses.asdict(container.get_total_size())
         click.echo(json.dumps(data, indent=2))
 
 
-@main.command("validate")
+@main.command('validate')
 @click.option(
-    "-v",
-    "--verbose",
+    '-v',
+    '--verbose',
     is_flag=True,
-    help="Print the full list of errors with respective hashkeys",
+    help='Print the full list of errors with respective hashkeys',
 )
 @pass_dostore
 def validate(dostore: ContainerContext, verbose: bool):
@@ -103,19 +103,19 @@ def validate(dostore: ContainerContext, verbose: bool):
 
             def callback(self, action, value):
                 """Callback method called periodically to update the progress bar."""
-                if action == "init":
+                if action == 'init':
                     if self.progress_bar is not None:
                         self.progress_bar.close()  # pragma: no cover
                     self.progress_bar = tqdm.tqdm(
-                        total=value["total"], desc=value["description"]
+                        total=value['total'], desc=value['description']
                     )
-                elif action == "update":
+                elif action == 'update':
                     value = value or 1  # If 0 or None
                     if self.progress_bar is None:
                         # Update without every initializing it?
                         return  # pragma: no cover
                     self.progress_bar.update(n=value)
-                elif action == "close":
+                elif action == 'close':
                     if self.progress_bar is not None:  # If not already closed
                         self.progress_bar.close()
                         self.progress_bar = None
@@ -125,7 +125,7 @@ def validate(dostore: ContainerContext, verbose: bool):
     except ImportError:
         callback = None
         click.echo(
-            "INFO: no `tqdm` package found. If you want to show a progress bar, install `pip tqdm` first.",
+            'INFO: no `tqdm` package found. If you want to show a progress bar, install `pip tqdm` first.',
             err=True,
         )
 
@@ -138,38 +138,38 @@ def validate(dostore: ContainerContext, verbose: bool):
             errors_found = True
             click.echo(f"Error! {len(value)} objects with error '{key}'")
     if not errors_found:
-        click.echo("No errors found, the container is valid.")
+        click.echo('No errors found, the container is valid.')
     if verbose and errors_found:
         click.echo(json.dumps(results, indent=2))
     if errors_found:
         sys.exit(1)
 
 
-@main.command("add-files")
-@click.argument("files", nargs=-1, type=click.Path(exists=True))
+@main.command('add-files')
+@click.argument('files', nargs=-1, type=click.Path(exists=True))
 @pass_dostore
 def add_files(dostore: ContainerContext, files: List[str]):
     """Add file(s) to the container"""
     with dostore.container as container:
         click.echo(
-            f"Adding {len(files)} file(s) to container: {container.get_folder()}"
+            f'Adding {len(files)} file(s) to container: {container.get_folder()}'
         )
         for filepath in files:
-            with open(filepath, "rb") as fobj:
+            with open(filepath, 'rb') as fobj:
                 hashkey = container.add_streamed_object(fobj)
-            click.echo(f"{hashkey}: {filepath}")
+            click.echo(f'{hashkey}: {filepath}')
 
 
-@main.command("optimize")
-@click.option("-n", "--non-interactive", is_flag=True, help="Do not confirm optimize")
+@main.command('optimize')
+@click.option('-n', '--non-interactive', is_flag=True, help='Do not confirm optimize')
 @click.option(
-    "--compress/--no-compress",
+    '--compress/--no-compress',
     default=True,
     show_default=True,
-    help="Compress objects before storing",
+    help='Compress objects before storing',
 )
 @click.option(
-    "--vacuum/--no-vacuum", default=True, show_default=True, help="Vacuum the database"
+    '--vacuum/--no-vacuum', default=True, show_default=True, help='Vacuum the database'
 )
 @pass_dostore
 def optimize(
@@ -177,34 +177,34 @@ def optimize(
 ):
     """Optimize the container's memory use"""
     if not non_interactive:
-        click.confirm("Is this the only process accessing the container?", abort=True)
-    size = sum(f.stat().st_size for f in dostore.path.glob("**/*") if f.is_file())
-    click.echo(f"Initial container size: {round(size/1000, 2)} Mb")
+        click.confirm('Is this the only process accessing the container?', abort=True)
+    size = sum(f.stat().st_size for f in dostore.path.glob('**/*') if f.is_file())
+    click.echo(f'Initial container size: {round(size/1000, 2)} Mb')
     with dostore.container as container:
         container.pack_all_loose(compress=compress)
         container.clean_storage(vacuum=vacuum)
-    size = sum(f.stat().st_size for f in dostore.path.glob("**/*") if f.is_file())
-    click.echo(f"Final container size: {round(size/1000, 2)} Mb")
+    size = sum(f.stat().st_size for f in dostore.path.glob('**/*') if f.is_file())
+    click.echo(f'Final container size: {round(size/1000, 2)} Mb')
 
 
-@main.command("backup")
-@click.argument("dest", nargs=1, type=click.Path())
+@main.command('backup')
+@click.argument('dest', nargs=1, type=click.Path())
 @click.option(
-    "--keep",
+    '--keep',
     default=1,
     show_default=True,
-    help="Number of previous backups to keep in the destination.",
+    help='Number of previous backups to keep in the destination.',
 )
 @click.option(
-    "--rsync-exe",
-    default="rsync",
+    '--rsync-exe',
+    default='rsync',
     help="Specify the 'rsync' executable, if not in PATH. Used for both local and remote destinations.",
 )
 @click.option(
-    "--verbosity",
-    default="info",
-    type=click.Choice(("silent", "info", "debug")),
-    help="Set verbosity of the logger.",
+    '--verbosity',
+    default='info',
+    type=click.Choice(('silent', 'info', 'debug')),
+    help='Set verbosity of the logger.',
 )
 @pass_dostore
 def backup(
@@ -233,14 +233,14 @@ def backup(
     non-UNIX environments.
     """
 
-    logging.basicConfig(format="%(levelname)s:%(message)s")
-    logger = logging.getLogger("disk_objectstore")
+    logging.basicConfig(format='%(levelname)s:%(message)s')
+    logger = logging.getLogger('disk_objectstore')
 
-    if verbosity == "silent":
+    if verbosity == 'silent':
         logger.setLevel(logging.ERROR)
-    elif verbosity == "info":
+    elif verbosity == 'info':
         logger.setLevel(logging.INFO)
-    elif verbosity == "debug":
+    elif verbosity == 'debug':
         logger.setLevel(logging.DEBUG)
 
     with dostore.container as container:
@@ -256,5 +256,5 @@ def backup(
                 )
             )
         except (ValueError, backup_utils.BackupError) as e:
-            click.echo(f"Error: {e}")
+            click.echo(f'Error: {e}')
             sys.exit(1)

--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -63,9 +63,7 @@ if TYPE_CHECKING:
 
     from mypy_extensions import Arg
 
-ObjQueryResults = namedtuple(
-    'ObjQueryResults', ['hashkey', 'offset', 'length', 'compressed', 'size']
-)
+ObjQueryResults = namedtuple('ObjQueryResults', ['hashkey', 'offset', 'length', 'compressed', 'size'])
 
 
 class ObjectType(Enum):
@@ -230,26 +228,18 @@ class Container:  # pylint: disable=too-many-public-methods
         :param hashkey: the hashkey of the object to get.
         """
         if self.loose_prefix_len:
-            return (
-                self._get_loose_folder()
-                / hashkey[: self.loose_prefix_len]
-                / hashkey[self.loose_prefix_len :]
-            )
+            return self._get_loose_folder() / hashkey[: self.loose_prefix_len] / hashkey[self.loose_prefix_len :]
         # if loose_prefix_len is zero, there is no subfolder
         return self._get_loose_folder() / hashkey
 
-    def _get_pack_path_from_pack_id(
-        self, pack_id: str | int, allow_repack_pack: bool = False
-    ) -> Path:
+    def _get_pack_path_from_pack_id(self, pack_id: str | int, allow_repack_pack: bool = False) -> Path:
         """Return the path of the pack file on disk for the given pack ID.
 
         :param pack_id: the pack ID.
         :param pack_id: Whether to allow the repack pack id
         """
         pack_id = str(pack_id)
-        assert self._is_valid_pack_id(
-            pack_id, allow_repack_pack=allow_repack_pack
-        ), f'Invalid pack ID {pack_id}'
+        assert self._is_valid_pack_id(pack_id, allow_repack_pack=allow_repack_pack), f'Invalid pack ID {pack_id}'
         return self._get_pack_folder() / pack_id
 
     def _get_pack_index_path(self) -> Path:
@@ -328,13 +318,9 @@ class Container:  # pylint: disable=too-many-public-methods
         :param compression_algorithm: a string defining the compression algorithm to use for compressed objects.
         """
         if loose_prefix_len < 0:
-            raise ValueError(
-                'The loose prefix length can only be zero or a positive integer'
-            )
+            raise ValueError('The loose prefix length can only be zero or a positive integer')
         if pack_size_target <= 0:
-            raise ValueError(
-                'The pack size target can only be a non-zero positive integer'
-            )
+            raise ValueError('The pack size target can only be a non-zero positive integer')
         if not is_known_hash(hash_type):
             raise ValueError(f'Unknown hash type "{hash_type}"')
 
@@ -405,9 +391,7 @@ class Container:  # pylint: disable=too-many-public-methods
         """Return the repository config."""
         if self._config is None:
             if not self.is_initialised:
-                raise NotInitialised(
-                    'The container is not initialised yet - use .init_container() first'
-                )
+                raise NotInitialised('The container is not initialised yet - use .init_container() first')
             with open(self._get_config_file(), encoding='utf8') as fhandle:
                 self._config = json.load(fhandle)
         return self._config
@@ -492,9 +476,7 @@ class Container:  # pylint: disable=too-many-public-methods
             yield fhandle
 
     @contextmanager
-    def get_object_stream_and_meta(
-        self, hashkey: str
-    ) -> Iterator[tuple[StreamReadBytesType, ObjectMeta],]:
+    def get_object_stream_and_meta(self, hashkey: str) -> Iterator[tuple[StreamReadBytesType, ObjectMeta],]:
         """Return a context manager yielding a stream to get the content of an object, and a metadata dictionary.
 
         To be used as a context manager::
@@ -510,9 +492,7 @@ class Container:  # pylint: disable=too-many-public-methods
 
         :param hashkey: the hashkey of the object to stream.
         """
-        with self.get_objects_stream_and_meta(
-            hashkeys=[hashkey], skip_if_missing=False
-        ) as triplets:
+        with self.get_objects_stream_and_meta(hashkeys=[hashkey], skip_if_missing=False) as triplets:
             counter = 0
             for (
                 obj_hashkey,
@@ -520,9 +500,7 @@ class Container:  # pylint: disable=too-many-public-methods
                 meta,
             ) in triplets:  # pylint: disable=not-an-iterable
                 counter += 1
-                assert (
-                    counter == 1
-                ), 'There is more than one item returned by get_objects_stream_and_meta'
+                assert counter == 1, 'There is more than one item returned by get_objects_stream_and_meta'
                 assert obj_hashkey == hashkey
 
                 if stream is None:
@@ -551,9 +529,7 @@ class Container:  # pylint: disable=too-many-public-methods
         hashkeys: Sequence[str],
         skip_if_missing: bool,
         with_streams: bool,
-    ) -> Iterator[
-        (tuple[str, ObjectMeta] | tuple[str, StreamSeekBytesType | None, ObjectMeta])
-    ]:
+    ) -> Iterator[(tuple[str, ObjectMeta] | tuple[str, StreamSeekBytesType | None, ObjectMeta])]:
         """Return a generator yielding triplets of (hashkey, open stream, size).
 
         :note: The stream is already open and at the right position, and can
@@ -607,26 +583,18 @@ class Container:  # pylint: disable=too-many-public-methods
                     Obj.size,
                 ).where(Obj.hashkey.in_(chunk))
                 for res in session.execute(stmt):
-                    packs[res[0]].append(
-                        ObjQueryResults(res[1], res[2], res[3], res[4], res[5])
-                    )
+                    packs[res[0]].append(ObjQueryResults(res[1], res[2], res[3], res[4], res[5]))
         else:
             sorted_hashkeys = sorted(hashkeys_set)
             pack_iterator = session.execute(
-                text(
-                    'SELECT pack_id, hashkey, offset, length, compressed, size FROM db_object ORDER BY hashkey'
-                )
+                text('SELECT pack_id, hashkey, offset, length, compressed, size FROM db_object ORDER BY hashkey')
             )
             # The left_key returns the second element of the tuple, i.e. the hashkey (that is the value to compare
             # with the right iterator)
-            for res, where in detect_where_sorted(
-                pack_iterator, sorted_hashkeys, left_key=lambda x: x[1]
-            ):
+            for res, where in detect_where_sorted(pack_iterator, sorted_hashkeys, left_key=lambda x: x[1]):
                 if where == Location.BOTH:
                     # If it's in both, it returns the left one, i.e. the full data from the DB
-                    packs[res[0]].append(
-                        ObjQueryResults(res[1], res[2], res[3], res[4], res[5])
-                    )
+                    packs[res[0]].append(ObjQueryResults(res[1], res[2], res[3], res[4], res[5]))
 
         for pack_int_id, pack_metadata in packs.items():
             pack_metadata.sort(key=lambda metadata: metadata.offset)
@@ -660,9 +628,7 @@ class Container:  # pylint: disable=too-many-public-methods
                             # I create a LazyLooseStream. It is the
                             # responsibility of the stream decompresser to open
                             # the stream if it feels it needs it.
-                            lazy_loose_stream = self.get_lazy_loose_stream(
-                                hashkey=metadata.hashkey
-                            )
+                            lazy_loose_stream = self.get_lazy_loose_stream(hashkey=metadata.hashkey)
                             obj_reader = self._get_stream_decompresser()(
                                 obj_reader, lazy_uncompressed_stream=lazy_loose_stream
                             )
@@ -670,10 +636,7 @@ class Container:  # pylint: disable=too-many-public-methods
                         # Here I check if the LazyLooseStream that I passed has
                         # been openeed - if so, I close it so I don't leave
                         # open file streams around
-                        if (
-                            lazy_loose_stream is not None
-                            and not lazy_loose_stream.closed
-                        ):
+                        if lazy_loose_stream is not None and not lazy_loose_stream.closed:
                             lazy_loose_stream.close_stream()
                     else:
                         yield metadata.hashkey, ObjectMeta(**meta)
@@ -746,9 +709,7 @@ class Container:  # pylint: disable=too-many-public-methods
             packs = defaultdict(list)
             session = self._get_operation_session()
             if len(loose_not_found) <= self._MAX_CHUNK_ITERATE_LENGTH:
-                for chunk in chunk_iterator(
-                    loose_not_found, size=self._IN_SQL_MAX_LENGTH
-                ):
+                for chunk in chunk_iterator(loose_not_found, size=self._IN_SQL_MAX_LENGTH):
                     stmt = select(
                         Obj.pack_id,
                         Obj.hashkey,
@@ -758,26 +719,18 @@ class Container:  # pylint: disable=too-many-public-methods
                         Obj.size,
                     ).where(Obj.hashkey.in_(chunk))
                     for res in session.execute(stmt):
-                        packs[res[0]].append(
-                            ObjQueryResults(res[1], res[2], res[3], res[4], res[5])
-                        )
+                        packs[res[0]].append(ObjQueryResults(res[1], res[2], res[3], res[4], res[5]))
             else:
                 sorted_hashkeys = sorted(loose_not_found)
                 pack_iterator = session.execute(
-                    text(
-                        'SELECT pack_id, hashkey, offset, length, compressed, size FROM db_object ORDER BY hashkey'
-                    )
+                    text('SELECT pack_id, hashkey, offset, length, compressed, size FROM db_object ORDER BY hashkey')
                 )
                 # The left_key returns the second element of the tuple, i.e. the hashkey (that is the value to compare
                 # with the right iterator)
-                for res, where in detect_where_sorted(
-                    pack_iterator, sorted_hashkeys, left_key=lambda x: x[1]
-                ):
+                for res, where in detect_where_sorted(pack_iterator, sorted_hashkeys, left_key=lambda x: x[1]):
                     if where == Location.BOTH:
                         # If it's in both, it returns the left one, i.e. the full data from the DB
-                        packs[res[0]].append(
-                            ObjQueryResults(res[1], res[2], res[3], res[4], res[5])
-                        )
+                        packs[res[0]].append(ObjQueryResults(res[1], res[2], res[3], res[4], res[5]))
 
             # I will construct here the really missing objects.
             # I make a copy of the set.
@@ -817,9 +770,7 @@ class Container:  # pylint: disable=too-many-public-methods
                                 # I create a LazyLooseStream.
                                 # It is the responsibility of the stream decompresser to open the stream if it feels it
                                 # needs it.
-                                lazy_loose_stream = self.get_lazy_loose_stream(
-                                    hashkey=metadata.hashkey
-                                )
+                                lazy_loose_stream = self.get_lazy_loose_stream(hashkey=metadata.hashkey)
                                 obj_reader = self._get_stream_decompresser()(
                                     obj_reader,
                                     lazy_uncompressed_stream=lazy_loose_stream,
@@ -828,10 +779,7 @@ class Container:  # pylint: disable=too-many-public-methods
                             # Here I check if the LazyLooseStream that I passed has
                             # been openeed - if so, I close it so I don't leave
                             # open file streams around
-                            if (
-                                lazy_loose_stream is not None
-                                and not lazy_loose_stream.closed
-                            ):
+                            if lazy_loose_stream is not None and not lazy_loose_stream.closed:
                                 lazy_loose_stream.close_stream()
                         else:
                             yield metadata.hashkey, ObjectMeta(**meta)
@@ -953,17 +901,13 @@ class Container:  # pylint: disable=too-many-public-methods
             hashkeys=[hashkey], skip_if_missing=False
         ):
             counter += 1
-            assert (
-                counter == 1
-            ), 'There is more than one item returned by get_objects_stream_and_meta'
+            assert counter == 1, 'There is more than one item returned by get_objects_stream_and_meta'
             assert obj_hashkey == hashkey
 
             if meta['type'] != ObjectType.MISSING:
                 return meta
 
-        assert (
-            counter == 1
-        ), 'No object found, this should never happen since I pass skip_if_missing=False!'
+        assert counter == 1, 'No object found, this should never happen since I pass skip_if_missing=False!'
         raise NotExistent(f'No object with hash key {hashkey}')
 
     def has_objects(self, hashkeys: list[str] | tuple[str, ...]) -> list[bool]:
@@ -993,9 +937,7 @@ class Container:  # pylint: disable=too-many-public-methods
         """
         return self.has_objects([hashkey])[0]
 
-    def get_objects_content(
-        self, hashkeys: list[str], skip_if_missing: bool = True
-    ) -> dict[str, bytes | None]:
+    def get_objects_content(self, hashkeys: list[str], skip_if_missing: bool = True) -> dict[str, bytes | None]:
         """Get the content of a number of objects with given hash keys.
 
         :note: use this method only if you know objects fit in memory.
@@ -1007,9 +949,7 @@ class Container:  # pylint: disable=too-many-public-methods
             are the object contents.
         """
         retrieved: dict[str, bytes | None] = {}
-        with self.get_objects_stream_and_meta(
-            hashkeys=hashkeys, skip_if_missing=skip_if_missing
-        ) as triplets:
+        with self.get_objects_stream_and_meta(hashkeys=hashkeys, skip_if_missing=skip_if_missing) as triplets:
             for obj_hashkey, stream, _ in triplets:  # pylint: disable=not-an-iterable
                 if stream is None:
                     # This should happen only if skip_if_missing is False
@@ -1073,9 +1013,7 @@ class Container:  # pylint: disable=too-many-public-methods
         In particular, it returns the number of loose objects,
         of packed objects, and the number of pack files."""
 
-        number_packed = self._get_operation_session().scalar(
-            select(func.count()).select_from(Obj)
-        )
+        number_packed = self._get_operation_session().scalar(select(func.count()).select_from(Obj))
         return ObjectCount(
             packed=number_packed,
             loose=sum(1 for _ in self._list_loose()),
@@ -1138,14 +1076,10 @@ class Container:  # pylint: disable=too-many-public-methods
 
         total_size_packfiles_on_disk = 0
         for pack_id in list(self._list_packs()):
-            total_size_packfiles_on_disk += (
-                self._get_pack_path_from_pack_id(pack_id).stat().st_size
-            )
+            total_size_packfiles_on_disk += self._get_pack_path_from_pack_id(pack_id).stat().st_size
         retval['total_size_packfiles_on_disk'] = total_size_packfiles_on_disk
 
-        retval['total_size_packindexes_on_disk'] = (
-            self._get_pack_index_path().stat().st_size
-        )
+        retval['total_size_packindexes_on_disk'] = self._get_pack_index_path().stat().st_size
 
         total_size_loose = 0
         for loose_hashkey in self._list_loose():
@@ -1156,9 +1090,7 @@ class Container:  # pylint: disable=too-many-public-methods
         return TotalSize(**retval)
 
     @contextmanager
-    def lock_pack(
-        self, pack_id: str, allow_repack_pack: bool = False
-    ) -> Iterator[StreamWriteBytesType]:
+    def lock_pack(self, pack_id: str, allow_repack_pack: bool = False) -> Iterator[StreamWriteBytesType]:
         """Lock the given pack id. Use as a context manager.
 
         Raise if the pack is already locked. If you enter the context manager,
@@ -1172,9 +1104,7 @@ class Container:  # pylint: disable=too-many-public-methods
 
         # Open file in exclusive mode
         lock_file = self._get_pack_folder() / f'{pack_id}.lock'
-        pack_file = self._get_pack_path_from_pack_id(
-            pack_id, allow_repack_pack=allow_repack_pack
-        )
+        pack_file = self._get_pack_path_from_pack_id(pack_id, allow_repack_pack=allow_repack_pack)
         try:
             with open(lock_file, 'x'):
                 with open(pack_file, 'ab') as pack_handle:
@@ -1241,12 +1171,7 @@ class Container:  # pylint: disable=too-many-public-methods
         # after this call was called. It would be bad instead to miss an object that has always existed
         last_pk = -1
         while True:
-            stmt = (
-                select(Obj.id, Obj.hashkey)
-                .where(Obj.id > last_pk)
-                .order_by(Obj.id)
-                .limit(yield_per_size)
-            )
+            stmt = select(Obj.id, Obj.hashkey).where(Obj.id > last_pk).order_by(Obj.id).limit(yield_per_size)
             results_chunk = session.execute(stmt).all()
 
             for _, hashkey in results_chunk:
@@ -1327,8 +1252,7 @@ class Container:  # pylint: disable=too-many-public-methods
         compress: bool | CompressMode = CompressMode.NO,
         validate_objects: bool = True,
         do_fsync: bool = True,
-        callback: None
-        | (Callable[[Arg(str, 'action'), Arg(Any, 'value')], None]) = None,
+        callback: None | (Callable[[Arg(str, 'action'), Arg(Any, 'value')], None]) = None,
     ) -> None:
         """Pack all loose objects.
 
@@ -1389,14 +1313,10 @@ class Container:  # pylint: disable=too-many-public-methods
                     existing_packed_hashkeys.append(res[0])
         else:
             sorted_hashkeys = sorted(loose_objects)
-            pack_iterator = session.execute(
-                text('SELECT hashkey FROM db_object ORDER BY hashkey')
-            )
+            pack_iterator = session.execute(text('SELECT hashkey FROM db_object ORDER BY hashkey'))
 
             # The query returns a tuple of length 1, so I still need a left_key
-            for res, where in detect_where_sorted(
-                pack_iterator, sorted_hashkeys, left_key=lambda x: x[0]
-            ):
+            for res, where in detect_where_sorted(pack_iterator, sorted_hashkeys, left_key=lambda x: x[0]):
                 if where == Location.BOTH:
                     existing_packed_hashkeys.append(res[0])
 
@@ -1460,9 +1380,7 @@ class Container:  # pylint: disable=too-many-public-methods
                     obj_dict['pack_id'] = pack_int_id
                     obj_dict['offset'] = pack_handle.tell()
                     try:
-                        with open(
-                            self._get_loose_path_from_hashkey(loose_hashkey), 'rb'
-                        ) as loose_handle:
+                        with open(self._get_loose_path_from_hashkey(loose_hashkey), 'rb') as loose_handle:
                             # It's always a standard file, I get its size
                             loose_size = os.fstat(loose_handle.fileno()).st_size
                             # Determine if I should compress this object or not.
@@ -1567,9 +1485,7 @@ class Container:  # pylint: disable=too-many-public-methods
         :return: a single object hash key
         """
         streams: list[StreamSeekBytesType] = [
-            CallbackStreamWrapper(
-                stream, callback=callback, total_length=callback_size_hint
-            )
+            CallbackStreamWrapper(stream, callback=callback, total_length=callback_size_hint)
         ]
 
         # I specifically set the callback to None
@@ -1667,12 +1583,7 @@ class Container:  # pylint: disable=too-many-public-methods
             # As this is expensive, I will do it only if it is needed, i.e. when no_holes is True
             last_pk = -1
             while True:
-                stmt = (
-                    select(Obj.id, Obj.hashkey)
-                    .where(Obj.id > last_pk)
-                    .order_by(Obj.id)
-                    .limit(yield_per_size)
-                )
+                stmt = select(Obj.id, Obj.hashkey).where(Obj.id > last_pk).order_by(Obj.id).limit(yield_per_size)
                 results_chunk = session.execute(stmt).all()
 
                 if not results_chunk:
@@ -1699,9 +1610,7 @@ class Container:  # pylint: disable=too-many-public-methods
         if callback:
             total = len(working_stream_list)
             # If we have a callback, compute the total count of objects in this pack
-            callback(
-                action='init', value={'total': total, 'description': 'Bulk storing'}
-            )
+            callback(action='init', value={'total': total, 'description': 'Bulk storing'})
             # Update at most 400 times, avoiding to increase CPU usage; if the list is small: every object.
             update_every = max(int(total / 400), 1)
             # Counter of how many objects have been since since the last update.
@@ -1922,12 +1831,8 @@ class Container:  # pylint: disable=too-many-public-methods
         :return: a list of object hash keys
         """
         if not self.is_initialised:
-            raise ValueError(
-                'Invalid use of function, please first initialise the container.'
-            )
-        stream_list: list[StreamSeekBytesType] = [
-            io.BytesIO(content) for content in content_list
-        ]
+            raise ValueError('Invalid use of function, please first initialise the container.')
+        stream_list: list[StreamSeekBytesType] = [io.BytesIO(content) for content in content_list]
         return self.add_streamed_objects_to_pack(
             stream_list=stream_list,
             compress=compress,
@@ -2050,12 +1955,8 @@ class Container:  # pylint: disable=too-many-public-methods
             else:
                 good_duplicate = None
                 for duplicate in duplicates_mapping[reference_obj_hashkey]:
-                    with open(
-                        self._get_duplicates_folder() / duplicate, 'rb'
-                    ) as fhandle:
-                        computed_hash, _ = compute_hash_and_size(
-                            fhandle, self.hash_type
-                        )
+                    with open(self._get_duplicates_folder() / duplicate, 'rb') as fhandle:
+                        computed_hash, _ = compute_hash_and_size(fhandle, self.hash_type)
                     if computed_hash == reference_obj_hashkey:
                         # We found a duplicate that has the correct hash key: let's put it in place
                         good_duplicate = duplicate
@@ -2094,14 +1995,10 @@ class Container:  # pylint: disable=too-many-public-methods
                     existing_packed_hashkeys.append(row[0])
         else:
             sorted_hashkeys = sorted(loose_objects)
-            pack_iterator = session.execute(
-                text('SELECT hashkey FROM db_object ORDER BY hashkey')
-            )
+            pack_iterator = session.execute(text('SELECT hashkey FROM db_object ORDER BY hashkey'))
 
             # The query returns a tuple of length 1, so I still need a left_key
-            for res, where in detect_where_sorted(
-                pack_iterator, sorted_hashkeys, left_key=lambda x: x[0]
-            ):
+            for res, where in detect_where_sorted(pack_iterator, sorted_hashkeys, left_key=lambda x: x[0]):
                 if where == Location.BOTH:
                     existing_packed_hashkeys.append(res[0])
 
@@ -2178,9 +2075,7 @@ class Container:  # pylint: disable=too-many-public-methods
             # see issue #94.
             # NOTE: I need to wrap in the `yield_first_element` iterator since it returns a list of lists
             sorted_packed = yield_first_element(
-                self._get_operation_session().execute(
-                    text('SELECT hashkey FROM db_object ORDER BY hashkey')
-                )
+                self._get_operation_session().execute(text('SELECT hashkey FROM db_object ORDER BY hashkey'))
             )
             sorted_existing = merge_sorted(sorted_loose, sorted_packed)
 
@@ -2220,9 +2115,7 @@ class Container:  # pylint: disable=too-many-public-methods
         if callback:
             # If we have a callback, compute the total count of objects in this pack
             total = len(hashkeys)
-            callback(
-                action='init', value={'total': total, 'description': 'Copy objects'}
-            )
+            callback(action='init', value={'total': total, 'description': 'Copy objects'})
             # Update at most 400 times, avoiding to increase CPU usage; if the list is small: every object.
             update_every = max(int(total / 1000), 1)
             # Counter of how many objects have been since since the last update.
@@ -2419,9 +2312,7 @@ class Container:  # pylint: disable=too-many-public-methods
 
         if callback:
             # If we have a callback, compute the total count of objects in this pack
-            total = session.scalar(
-                select(func.count()).select_from(Obj).where(Obj.pack_id == pack_id)
-            )
+            total = session.scalar(select(func.count()).select_from(Obj).where(Obj.pack_id == pack_id))
             callback(
                 action='init',
                 value={'total': total, 'description': f'Pack {pack_id}'},
@@ -2442,9 +2333,7 @@ class Container:  # pylint: disable=too-many-public-methods
                 .order_by(Obj.offset)
             )
             for hashkey, size, offset, length, compressed in session.execute(stmt):
-                obj_reader: StreamSeekBytesType = PackedObjectReader(
-                    fhandle=pack_handle, offset=offset, length=length
-                )
+                obj_reader: StreamSeekBytesType = PackedObjectReader(fhandle=pack_handle, offset=offset, length=length)
                 if compressed:
                     # I don't pass a LazyLooseStream: in the validate
                     # I should only ever read linearly, so it should not be needed
@@ -2452,9 +2341,7 @@ class Container:  # pylint: disable=too-many-public-methods
                     # of the object.
                     obj_reader = self._get_stream_decompresser()(obj_reader)
 
-                computed_hash, computed_size = compute_hash_and_size(
-                    obj_reader, self.hash_type
-                )
+                computed_hash, computed_size = compute_hash_and_size(obj_reader, self.hash_type)
 
                 # Check object correctness
                 if computed_hash != hashkey:
@@ -2497,9 +2384,7 @@ class Container:  # pylint: disable=too-many-public-methods
         dataclass to check if there are errors, or check all fields if you
         prefer and see if all fields are empty lists (which means no error).
         """
-        all_errors: dict[str, list[str]] = {
-            field.name: [] for field in dataclasses.fields(ValidationIssues)
-        }
+        all_errors: dict[str, list[str]] = {field.name: [] for field in dataclasses.fields(ValidationIssues)}
 
         all_loose = set(self._list_loose())
 
@@ -2522,14 +2407,10 @@ class Container:  # pylint: disable=too-many-public-methods
 
         session = self._get_operation_session()
 
-        all_pack_ids = sorted(
-            {res[0] for res in session.execute(select(Obj.pack_id).distinct())}
-        )
+        all_pack_ids = sorted({res[0] for res in session.execute(select(Obj.pack_id).distinct())})
 
         for pack_id in all_pack_ids:
-            pack_errors = self._validate_hashkeys_pack(
-                pack_id=pack_id, callback=callback
-            )
+            pack_errors = self._validate_hashkeys_pack(pack_id=pack_id, callback=callback)
             for error_type, problematic_objects in pack_errors.items():
                 all_errors[error_type] += problematic_objects
 
@@ -2579,9 +2460,7 @@ class Container:  # pylint: disable=too-many-public-methods
         for hashkey in hashkeys:
             # Filter only duplicates of this object and delete them
             duplicates_this_object = [
-                duplicate_fname
-                for duplicate_fname in all_duplicates
-                if duplicate_fname.startswith(f'{hashkey}.')
+                duplicate_fname for duplicate_fname in all_duplicates if duplicate_fname.startswith(f'{hashkey}.')
             ]
             for duplicate_fname in duplicates_this_object:
                 # For now I don't put checks - I should be the only one accessing the container, so I should not
@@ -2606,11 +2485,7 @@ class Container:  # pylint: disable=too-many-public-methods
             # `'fetch'` will run the query twice so it's less efficient
             # False is beter but one needs to either `expire_all` at the end, or commit.
             # I will commit at the end.
-            stmt = (
-                delete(Obj)
-                .where(Obj.hashkey.in_(chunk))
-                .execution_options(synchronize_session=False)
-            )
+            stmt = delete(Obj).where(Obj.hashkey.in_(chunk)).execution_options(synchronize_session=False)
             session.execute(stmt)
             deleted_packed.update(deleted_this_chunk)
 
@@ -2625,8 +2500,7 @@ class Container:  # pylint: disable=too-many-public-methods
     def repack(
         self,
         compress_mode: CompressMode = CompressMode.KEEP,
-        callback: None
-        | (Callable[[Arg(str, 'action'), Arg(Any, 'value')], None]) = None,
+        callback: None | (Callable[[Arg(str, 'action'), Arg(Any, 'value')], None]) = None,
     ) -> None:
         """Perform a repack of all packed objects.
 
@@ -2654,8 +2528,7 @@ class Container:  # pylint: disable=too-many-public-methods
         self,
         pack_id: str,
         compress_mode: CompressMode = CompressMode.KEEP,
-        callback: None
-        | (Callable[[Arg(str, 'action'), Arg(Any, 'value')], None]) = None,
+        callback: None | (Callable[[Arg(str, 'action'), Arg(Any, 'value')], None]) = None,
     ) -> None:
         """Perform a repack of a given pack object.
 
@@ -2687,9 +2560,7 @@ class Container:  # pylint: disable=too-many-public-methods
 
         session = self._get_operation_session()
 
-        one_object_in_pack = session.execute(
-            select(Obj.id).where(Obj.pack_id == pack_id).limit(1)
-        ).all()
+        one_object_in_pack = session.execute(select(Obj.id).where(Obj.pack_id == pack_id).limit(1)).all()
         if not one_object_in_pack:
             # No objects. Clean up the pack file, if it exists.
             if self._get_pack_path_from_pack_id(pack_id).exists():
@@ -2707,9 +2578,7 @@ class Container:  # pylint: disable=too-many-public-methods
                     'description': f'Repack {pack_id}',
                 },
             )
-        with self.lock_pack(
-            str(self._REPACK_PACK_ID), allow_repack_pack=True
-        ) as write_pack_handle:
+        with self.lock_pack(str(self._REPACK_PACK_ID), allow_repack_pack=True) as write_pack_handle:
             with open(self._get_pack_path_from_pack_id(pack_id), 'rb') as read_pack:
                 stmt = (
                     select(
@@ -2732,8 +2601,8 @@ class Container:  # pylint: disable=too-many-public-methods
                     source_compressed,
                 ) in session.execute(stmt):
                     # This is the read handle of the bytes in the pack - it might be
-                    read_handle: PackedObjectReader | ZlibStreamDecompresser = (
-                        PackedObjectReader(read_pack, offset, length)
+                    read_handle: PackedObjectReader | ZlibStreamDecompresser = PackedObjectReader(
+                        read_pack, offset, length
                     )
 
                     # Determine if I should compress or not the destination - this function will
@@ -2809,9 +2678,7 @@ class Container:  # pylint: disable=too-many-public-methods
             # safe flush to disk seems to be a time consuming operation, but no easy way to include in the progress bar
             safe_flush_to_disk(
                 write_pack_handle,
-                self._get_pack_path_from_pack_id(
-                    self._REPACK_PACK_ID, allow_repack_pack=True
-                ),
+                self._get_pack_path_from_pack_id(self._REPACK_PACK_ID, allow_repack_pack=True),
             )
         if callback:
             callback(action='close', value=None)
@@ -2827,9 +2694,7 @@ class Container:  # pylint: disable=too-many-public-methods
 
         # Now we can safely delete the old object. I just check that there is no object still
         # refencing the old pack, to be sure.
-        one_object_in_pack = session.execute(
-            select(Obj.id).where(Obj.pack_id == pack_id).limit(1)
-        ).all()
+        one_object_in_pack = session.execute(select(Obj.id).where(Obj.pack_id == pack_id).limit(1)).all()
         assert not one_object_in_pack, (
             f"I moved the objects of pack '{pack_id}' to pack '{self._REPACK_PACK_ID}' "
             f"but there are still references to pack '{pack_id}'!"
@@ -2841,29 +2706,19 @@ class Container:  # pylint: disable=too-many-public-methods
         # Since hard links seem to be supported on all three platforms, I do a hard link
         # of -1 back to the correct pack ID.
         os.link(
-            self._get_pack_path_from_pack_id(
-                self._REPACK_PACK_ID, allow_repack_pack=True
-            ),
+            self._get_pack_path_from_pack_id(self._REPACK_PACK_ID, allow_repack_pack=True),
             self._get_pack_path_from_pack_id(pack_id),
         )
 
         # Before deleting the source (pack -1) I need now to update again all
         # entries to point to the correct pack id
-        session.execute(
-            update(Obj)
-            .where(Obj.pack_id == self._REPACK_PACK_ID)
-            .values(pack_id=pack_id)
-        )
+        session.execute(update(Obj).where(Obj.pack_id == self._REPACK_PACK_ID).values(pack_id=pack_id))
         session.commit()
 
         # Technically, to be crash safe, before deleting I should also fsync the folder
         # I am not doing this for now
         # I now can unlink/delete the original source
-        os.unlink(
-            self._get_pack_path_from_pack_id(
-                self._REPACK_PACK_ID, allow_repack_pack=True
-            )
-        )
+        os.unlink(self._get_pack_path_from_pack_id(self._REPACK_PACK_ID, allow_repack_pack=True))
 
         # We are now done. The temporary pack is gone, and the old `pack_id`
         # has now been replaced with an udpated, repacked pack.

--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -56,37 +56,30 @@ if TYPE_CHECKING:
     from typing import (
         Any,
         Callable,
-        Dict,
         Iterator,
-        List,
         Literal,
-        Optional,
         Sequence,
-        Set,
-        Tuple,
-        Type,
-        Union,
     )
 
     from mypy_extensions import Arg
 
 ObjQueryResults = namedtuple(
-    "ObjQueryResults", ["hashkey", "offset", "length", "compressed", "size"]
+    'ObjQueryResults', ['hashkey', 'offset', 'length', 'compressed', 'size']
 )
 
 
 class ObjectType(Enum):
     """Enum that describes the various types of an objec (as returned in ``meta['type']``)."""
 
-    LOOSE = "loose"
-    PACKED = "packed"
-    MISSING = "missing"
+    LOOSE = 'loose'
+    PACKED = 'packed'
+    MISSING = 'missing'
 
 
 class Container:  # pylint: disable=too-many-public-methods
     """A class representing a container of objects (which is stored on a disk folder)"""
 
-    _PACK_INDEX_SUFFIX = ".idx"
+    _PACK_INDEX_SUFFIX = '.idx'
     # Size in bytes of each of the chunks used when (internally) reading or writing in chunks, e.g.
     # when packing.
     _CHUNKSIZE = 65536
@@ -177,21 +170,21 @@ class Container:  # pylint: disable=too-many-public-methods
 
         It is a subfolder of the container folder.
         """
-        return self._folder / "sandbox"
+        return self._folder / 'sandbox'
 
     def _get_loose_folder(self) -> Path:
         """Return the path to the folder that will host the loose objects.
 
         It is a subfolder of the container folder.
         """
-        return self._folder / "loose"
+        return self._folder / 'loose'
 
     def _get_pack_folder(self) -> Path:
         """Return the path to the folder that will host the packed objects.
 
         It is a subfolder of the container folder.
         """
-        return self._folder / "packs"
+        return self._folder / 'packs'
 
     def _get_duplicates_folder(self) -> Path:
         """Return the path to the folder that will host the duplicate loose objects that couldn't be written.
@@ -201,11 +194,11 @@ class Container:  # pylint: disable=too-many-public-methods
 
         It is a subfolder of the container folder.
         """
-        return self._folder / "duplicates"
+        return self._folder / 'duplicates'
 
     def _get_config_file(self) -> Path:
         """Return the path to the container config file."""
-        return self._folder / "config.json"
+        return self._folder / 'config.json'
 
     def _get_container_session(self) -> Session:
         """Return the container session to connect to the pack-index SQLite DB.
@@ -256,12 +249,12 @@ class Container:  # pylint: disable=too-many-public-methods
         pack_id = str(pack_id)
         assert self._is_valid_pack_id(
             pack_id, allow_repack_pack=allow_repack_pack
-        ), f"Invalid pack ID {pack_id}"
+        ), f'Invalid pack ID {pack_id}'
         return self._get_pack_folder() / pack_id
 
     def _get_pack_index_path(self) -> Path:
         """Return the path to the SQLite file containing the index of packed objects."""
-        return self._folder / f"packs{self._PACK_INDEX_SUFFIX}"
+        return self._folder / f'packs{self._PACK_INDEX_SUFFIX}'
 
     def _get_pack_id_to_write_to(self) -> int:
         """Return the pack ID to write the next object.
@@ -295,7 +288,7 @@ class Container:  # pylint: disable=too-many-public-methods
         """Return True if the container is already initialised."""
         # If the config file does not exist, the container is not initialised
         try:
-            with open(self._get_config_file(), encoding="utf8") as fhandle:
+            with open(self._get_config_file(), encoding='utf8') as fhandle:
                 json.load(fhandle)
         except (ValueError, OSError):
             return False
@@ -316,8 +309,8 @@ class Container:  # pylint: disable=too-many-public-methods
         clear: bool = False,
         pack_size_target: int = 4 * 1024 * 1024 * 1024,
         loose_prefix_len: int = 2,
-        hash_type: str = "sha256",
-        compression_algorithm: str = "zlib+1",
+        hash_type: str = 'sha256',
+        compression_algorithm: str = 'zlib+1',
     ) -> None:
         """Initialise the container folder, if not already done.
 
@@ -336,11 +329,11 @@ class Container:  # pylint: disable=too-many-public-methods
         """
         if loose_prefix_len < 0:
             raise ValueError(
-                "The loose prefix length can only be zero or a positive integer"
+                'The loose prefix length can only be zero or a positive integer'
             )
         if pack_size_target <= 0:
             raise ValueError(
-                "The pack size target can only be a non-zero positive integer"
+                'The pack size target can only be a non-zero positive integer'
             )
         if not is_known_hash(hash_type):
             raise ValueError(f'Unknown hash type "{hash_type}"')
@@ -357,8 +350,8 @@ class Container:  # pylint: disable=too-many-public-methods
 
         if self.is_initialised:
             raise FileExistsError(
-                "The container already exists, so you cannot initialise it - "
-                "use the clear option if you want to overwrite with a clean one"
+                'The container already exists, so you cannot initialise it - '
+                'use the clear option if you want to overwrite with a clean one'
             )
 
         # If we are here, either the folder is empty, or just cleared.
@@ -376,7 +369,7 @@ class Container:  # pylint: disable=too-many-public-methods
 
         if os.listdir(self._folder):
             raise FileExistsError(
-                "There is already some file or folder in the Container folder, I cannot initialise it!"
+                'There is already some file or folder in the Container folder, I cannot initialise it!'
             )
 
         # validate the compression algorithm: check if I'm able to load the classes to compress and decompress
@@ -385,15 +378,15 @@ class Container:  # pylint: disable=too-many-public-methods
         get_stream_decompresser(compression_algorithm)
 
         # Create config file
-        with open(self._get_config_file(), "w", encoding="utf8") as fhandle:
+        with open(self._get_config_file(), 'w', encoding='utf8') as fhandle:
             json.dump(
                 {
-                    "container_version": 1,  # For future compatibility, this is the version of the format
-                    "loose_prefix_len": loose_prefix_len,
-                    "pack_size_target": pack_size_target,
-                    "hash_type": hash_type,
-                    "container_id": container_id,
-                    "compression_algorithm": compression_algorithm,
+                    'container_version': 1,  # For future compatibility, this is the version of the format
+                    'loose_prefix_len': loose_prefix_len,
+                    'pack_size_target': pack_size_target,
+                    'hash_type': hash_type,
+                    'container_id': container_id,
+                    'compression_algorithm': compression_algorithm,
                 },
                 fhandle,
             )
@@ -413,9 +406,9 @@ class Container:  # pylint: disable=too-many-public-methods
         if self._config is None:
             if not self.is_initialised:
                 raise NotInitialised(
-                    "The container is not initialised yet - use .init_container() first"
+                    'The container is not initialised yet - use .init_container() first'
                 )
-            with open(self._get_config_file(), encoding="utf8") as fhandle:
+            with open(self._get_config_file(), encoding='utf8') as fhandle:
                 self._config = json.load(fhandle)
         return self._config
 
@@ -425,7 +418,7 @@ class Container:  # pylint: disable=too-many-public-methods
 
         This is read from the (cached) repository configuration.
         """
-        return self._get_repository_config()["loose_prefix_len"]  # type: ignore[return-value]
+        return self._get_repository_config()['loose_prefix_len']  # type: ignore[return-value]
 
     @property
     def pack_size_target(self) -> int:
@@ -433,7 +426,7 @@ class Container:  # pylint: disable=too-many-public-methods
 
         This is read from the (cached) repository configuration.
         """
-        return self._get_repository_config()["pack_size_target"]  # type: ignore[return-value]
+        return self._get_repository_config()['pack_size_target']  # type: ignore[return-value]
 
     @property
     def hash_type(self) -> str:
@@ -441,7 +434,7 @@ class Container:  # pylint: disable=too-many-public-methods
 
         This is read from the (cached) repository configuration.
         """
-        return self._get_repository_config()["hash_type"]  # type: ignore[return-value]
+        return self._get_repository_config()['hash_type']  # type: ignore[return-value]
 
     @property
     def container_id(self) -> str:
@@ -453,14 +446,14 @@ class Container:  # pylint: disable=too-many-public-methods
 
         Clones of the container should have a different ID even if they have the same content.
         """
-        return self._get_repository_config()["container_id"]  # type: ignore[return-value]
+        return self._get_repository_config()['container_id']  # type: ignore[return-value]
 
     @property
     def compression_algorithm(self) -> str:
         """Return the compression algorithm defined for this container.
 
         This is read from the repository configuration."""
-        return self._get_repository_config()["compression_algorithm"]  # type: ignore[return-value]
+        return self._get_repository_config()['compression_algorithm']  # type: ignore[return-value]
 
     def _get_compressobj_instance(self):
         """Return the correct `compressobj` class for the compression algorithm defined for this container."""
@@ -529,11 +522,11 @@ class Container:  # pylint: disable=too-many-public-methods
                 counter += 1
                 assert (
                     counter == 1
-                ), "There is more than one item returned by get_objects_stream_and_meta"
+                ), 'There is more than one item returned by get_objects_stream_and_meta'
                 assert obj_hashkey == hashkey
 
                 if stream is None:
-                    raise NotExistent(f"No object with hash key {hashkey}")
+                    raise NotExistent(f'No object with hash key {hashkey}')
 
                 yield stream, meta
 
@@ -543,8 +536,7 @@ class Container:  # pylint: disable=too-many-public-methods
         hashkeys: Sequence[str],
         skip_if_missing: bool,
         with_streams: Literal[False],
-    ) -> Iterator[tuple[str, ObjectMeta]]:
-        ...
+    ) -> Iterator[tuple[str, ObjectMeta]]: ...
 
     @overload
     def _get_objects_stream_meta_generator(
@@ -552,8 +544,7 @@ class Container:  # pylint: disable=too-many-public-methods
         hashkeys: Sequence[str],
         skip_if_missing: bool,
         with_streams: Literal[True],
-    ) -> Iterator[tuple[str, StreamSeekBytesType | None, ObjectMeta]]:
-        ...
+    ) -> Iterator[tuple[str, StreamSeekBytesType | None, ObjectMeta]]: ...
 
     def _get_objects_stream_meta_generator(  # pylint: disable=too-many-branches,too-many-statements,too-many-locals
         self,
@@ -623,7 +614,7 @@ class Container:  # pylint: disable=too-many-public-methods
             sorted_hashkeys = sorted(hashkeys_set)
             pack_iterator = session.execute(
                 text(
-                    "SELECT pack_id, hashkey, offset, length, compressed, size FROM db_object ORDER BY hashkey"
+                    'SELECT pack_id, hashkey, offset, length, compressed, size FROM db_object ORDER BY hashkey'
                 )
             )
             # The left_key returns the second element of the tuple, i.e. the hashkey (that is the value to compare
@@ -645,16 +636,16 @@ class Container:  # pylint: disable=too-many-public-methods
                 # Open only once per file (if in `with_streams` mode)
                 if with_streams:
                     last_open_file = open(  # pylint: disable=consider-using-with
-                        pack_path, mode="rb"
+                        pack_path, mode='rb'
                     )
                 for metadata in pack_metadata:
                     meta = {
-                        "type": ObjectType.PACKED,
-                        "size": metadata.size,
-                        "pack_id": pack_int_id,
-                        "pack_compressed": metadata.compressed,
-                        "pack_offset": metadata.offset,
-                        "pack_length": metadata.length,
+                        'type': ObjectType.PACKED,
+                        'size': metadata.size,
+                        'pack_id': pack_int_id,
+                        'pack_compressed': metadata.compressed,
+                        'pack_offset': metadata.offset,
+                        'pack_length': metadata.length,
                     }
 
                     if with_streams:
@@ -700,18 +691,18 @@ class Container:  # pylint: disable=too-many-public-methods
             try:
                 if with_streams:
                     last_open_file = open(  # pylint: disable=consider-using-with
-                        obj_path, mode="rb"
+                        obj_path, mode='rb'
                     )
                     # I do not use Pathlib to get the size, in case the file has just
                     # been deleted by a concurrent writer, but I use the lower-level os.fstat
                     # on the fileno() of the open file
                     meta = {
-                        "type": ObjectType.LOOSE,
-                        "size": os.fstat(last_open_file.fileno()).st_size,
-                        "pack_id": None,
-                        "pack_compressed": None,
-                        "pack_offset": None,
-                        "pack_length": None,
+                        'type': ObjectType.LOOSE,
+                        'size': os.fstat(last_open_file.fileno()).st_size,
+                        'pack_id': None,
+                        'pack_compressed': None,
+                        'pack_offset': None,
+                        'pack_length': None,
                     }
 
                     yield loose_hashkey, last_open_file, ObjectMeta(**meta)
@@ -719,12 +710,12 @@ class Container:  # pylint: disable=too-many-public-methods
                     # This will also raise a FileNotFoundError if the file does not exist
                     size = obj_path.stat().st_size
                     meta = {
-                        "type": ObjectType.LOOSE,
-                        "size": size,
-                        "pack_id": None,
-                        "pack_compressed": None,
-                        "pack_offset": None,
-                        "pack_length": None,
+                        'type': ObjectType.LOOSE,
+                        'size': size,
+                        'pack_id': None,
+                        'pack_compressed': None,
+                        'pack_offset': None,
+                        'pack_length': None,
                     }
 
                     yield loose_hashkey, ObjectMeta(**meta)
@@ -774,7 +765,7 @@ class Container:  # pylint: disable=too-many-public-methods
                 sorted_hashkeys = sorted(loose_not_found)
                 pack_iterator = session.execute(
                     text(
-                        "SELECT pack_id, hashkey, offset, length, compressed, size FROM db_object ORDER BY hashkey"
+                        'SELECT pack_id, hashkey, offset, length, compressed, size FROM db_object ORDER BY hashkey'
                     )
                 )
                 # The left_key returns the second element of the tuple, i.e. the hashkey (that is the value to compare
@@ -801,17 +792,17 @@ class Container:  # pylint: disable=too-many-public-methods
                 try:
                     if with_streams:
                         last_open_file = open(  # pylint: disable=consider-using-with
-                            pack_path, mode="rb"
+                            pack_path, mode='rb'
                         )
 
                     for metadata in pack_metadata:
                         meta = {
-                            "type": ObjectType.PACKED,
-                            "size": metadata.size,
-                            "pack_id": pack_int_id,
-                            "pack_compressed": metadata.compressed,
-                            "pack_offset": metadata.offset,
-                            "pack_length": metadata.length,
+                            'type': ObjectType.PACKED,
+                            'size': metadata.size,
+                            'pack_id': pack_int_id,
+                            'pack_compressed': metadata.compressed,
+                            'pack_offset': metadata.offset,
+                            'pack_length': metadata.length,
                         }
                         if with_streams:
                             assert last_open_file is not None
@@ -853,12 +844,12 @@ class Container:  # pylint: disable=too-many-public-methods
             if really_not_found and not skip_if_missing:
                 for missing_hashkey in really_not_found:
                     meta = {
-                        "type": ObjectType.MISSING,
-                        "size": None,
-                        "pack_id": None,
-                        "pack_compressed": None,
-                        "pack_offset": None,
-                        "pack_length": None,
+                        'type': ObjectType.MISSING,
+                        'size': None,
+                        'pack_id': None,
+                        'pack_compressed': None,
+                        'pack_offset': None,
+                        'pack_length': None,
                     }
                     if with_streams:
                         yield missing_hashkey, None, ObjectMeta(**meta)
@@ -964,16 +955,16 @@ class Container:  # pylint: disable=too-many-public-methods
             counter += 1
             assert (
                 counter == 1
-            ), "There is more than one item returned by get_objects_stream_and_meta"
+            ), 'There is more than one item returned by get_objects_stream_and_meta'
             assert obj_hashkey == hashkey
 
-            if meta["type"] != ObjectType.MISSING:
+            if meta['type'] != ObjectType.MISSING:
                 return meta
 
         assert (
             counter == 1
-        ), "No object found, this should never happen since I pass skip_if_missing=False!"
-        raise NotExistent(f"No object with hash key {hashkey}")
+        ), 'No object found, this should never happen since I pass skip_if_missing=False!'
+        raise NotExistent(f'No object with hash key {hashkey}')
 
     def has_objects(self, hashkeys: list[str] | tuple[str, ...]) -> list[bool]:
         """Return whether the container contains objects with the given hash keys.
@@ -1100,12 +1091,12 @@ class Container:  # pylint: disable=too-many-public-methods
         if not pack_id:
             # Must be a non-empty string
             return False
-        if pack_id != "0" and pack_id[0] == "0":
+        if pack_id != '0' and pack_id[0] == '0':
             # The ID must be a valid integer: either zero, or it should not start by zero
             return False
         if allow_repack_pack and pack_id == str(cls._REPACK_PACK_ID):
             return True
-        if not all(char in "0123456789" for char in pack_id):
+        if not all(char in '0123456789' for char in pack_id):
             return False
         return True
 
@@ -1113,7 +1104,7 @@ class Container:  # pylint: disable=too-many-public-methods
         """Return True if the name is a valid prefix."""
         if len(prefix) != self.loose_prefix_len:
             return False
-        if not all(char in "0123456789abcdef" for char in prefix):
+        if not all(char in '0123456789abcdef' for char in prefix):
             return False
         return True
 
@@ -1124,7 +1115,7 @@ class Container:  # pylint: disable=too-many-public-methods
         Note that it currently does not check the length but only that the key is composed only
         by hexadecimal characters.
         """
-        if not all(char in "0123456789abcdef" for char in hashkey):
+        if not all(char in '0123456789abcdef' for char in hashkey):
             return False
         return True
 
@@ -1138,11 +1129,11 @@ class Container:  # pylint: disable=too-many-public-methods
         session = self._get_operation_session()
         # COALESCE is used to return 0 if there are no results, rather than None
         # SQL's COALESCE returns the first non-null result
-        retval["total_size_packed"] = session.scalar(
-            select(func.coalesce(func.sum(Obj.size), 0).label("total_size_packed"))
+        retval['total_size_packed'] = session.scalar(
+            select(func.coalesce(func.sum(Obj.size), 0).label('total_size_packed'))
         )
-        retval["total_size_packed_on_disk"] = session.scalar(
-            select(func.coalesce(func.sum(Obj.length), 0).label("total_length_packed"))
+        retval['total_size_packed_on_disk'] = session.scalar(
+            select(func.coalesce(func.sum(Obj.length), 0).label('total_length_packed'))
         )
 
         total_size_packfiles_on_disk = 0
@@ -1150,9 +1141,9 @@ class Container:  # pylint: disable=too-many-public-methods
             total_size_packfiles_on_disk += (
                 self._get_pack_path_from_pack_id(pack_id).stat().st_size
             )
-        retval["total_size_packfiles_on_disk"] = total_size_packfiles_on_disk
+        retval['total_size_packfiles_on_disk'] = total_size_packfiles_on_disk
 
-        retval["total_size_packindexes_on_disk"] = (
+        retval['total_size_packindexes_on_disk'] = (
             self._get_pack_index_path().stat().st_size
         )
 
@@ -1160,7 +1151,7 @@ class Container:  # pylint: disable=too-many-public-methods
         for loose_hashkey in self._list_loose():
             loose_path = self._get_loose_path_from_hashkey(loose_hashkey)
             total_size_loose += loose_path.stat().st_size
-        retval["total_size_loose"] = total_size_loose
+        retval['total_size_loose'] = total_size_loose
 
         return TotalSize(**retval)
 
@@ -1180,13 +1171,13 @@ class Container:  # pylint: disable=too-many-public-methods
         assert self._is_valid_pack_id(pack_id, allow_repack_pack=allow_repack_pack)
 
         # Open file in exclusive mode
-        lock_file = self._get_pack_folder() / f"{pack_id}.lock"
+        lock_file = self._get_pack_folder() / f'{pack_id}.lock'
         pack_file = self._get_pack_path_from_pack_id(
             pack_id, allow_repack_pack=allow_repack_pack
         )
         try:
-            with open(lock_file, "x"):
-                with open(pack_file, "ab") as pack_handle:
+            with open(lock_file, 'x'):
+                with open(pack_file, 'ab') as pack_handle:
                     yield pack_handle
         finally:
             # Release resource (I check if it exists in case there was an exception)
@@ -1205,7 +1196,7 @@ class Container:  # pylint: disable=too-many-public-methods
                 if not self._is_valid_loose_prefix(first_level):
                     continue
                 for second_level in os.listdir(self._get_loose_folder() / first_level):
-                    hashkey = f"{first_level}{second_level}"
+                    hashkey = f'{first_level}{second_level}'
                     if not self._is_valid_hashkey(hashkey):
                         continue
                     yield hashkey
@@ -1299,8 +1290,8 @@ class Container:  # pylint: disable=too-many-public-methods
             size and ``hash_key`` is ``None`` is ``hash_type`` is ``None``, otherwise it contains the hash
             computed with the given ``hash_type`` algorithm.
         """
-        assert "b" in pack_handle.mode
-        assert "a" in pack_handle.mode
+        assert 'b' in pack_handle.mode
+        assert 'a' in pack_handle.mode
 
         if hash_type:
             hasher = get_hash_cls(hash_type=hash_type)()
@@ -1311,7 +1302,7 @@ class Container:  # pylint: disable=too-many-public-methods
         count_read_bytes = 0
         while True:
             chunk = read_handle.read(self._CHUNKSIZE)
-            if chunk == b"":
+            if chunk == b'':
                 # Returns an empty bytes object on EOF.
                 # Returns None if the underlying raw stream was open in non-blocking
                 # mode and no data is available at the moment.
@@ -1337,7 +1328,7 @@ class Container:  # pylint: disable=too-many-public-methods
         validate_objects: bool = True,
         do_fsync: bool = True,
         callback: None
-        | (Callable[[Arg(str, "action"), Arg(Any, "value")], None]) = None,
+        | (Callable[[Arg(str, 'action'), Arg(Any, 'value')], None]) = None,
     ) -> None:
         """Pack all loose objects.
 
@@ -1399,7 +1390,7 @@ class Container:  # pylint: disable=too-many-public-methods
         else:
             sorted_hashkeys = sorted(loose_objects)
             pack_iterator = session.execute(
-                text("SELECT hashkey FROM db_object ORDER BY hashkey")
+                text('SELECT hashkey FROM db_object ORDER BY hashkey')
             )
 
             # The query returns a tuple of length 1, so I still need a left_key
@@ -1423,10 +1414,10 @@ class Container:  # pylint: disable=too-many-public-methods
 
         if callback:
             callback(
-                action="init",
+                action='init',
                 value={
-                    "total": self.get_total_size()["total_size_loose"],
-                    "description": "Packing loose objects",
+                    'total': self.get_total_size()['total_size_loose'],
+                    'description': 'Packing loose objects',
                 },
             )
             # I wish this would show as MB, GB. In tqdm it's easy:
@@ -1465,19 +1456,19 @@ class Container:  # pylint: disable=too-many-public-methods
                     loose_hashkey = loose_objects.pop()
 
                     obj_dict: dict[str, Any] = {}
-                    obj_dict["hashkey"] = loose_hashkey
-                    obj_dict["pack_id"] = pack_int_id
-                    obj_dict["offset"] = pack_handle.tell()
+                    obj_dict['hashkey'] = loose_hashkey
+                    obj_dict['pack_id'] = pack_int_id
+                    obj_dict['offset'] = pack_handle.tell()
                     try:
                         with open(
-                            self._get_loose_path_from_hashkey(loose_hashkey), "rb"
+                            self._get_loose_path_from_hashkey(loose_hashkey), 'rb'
                         ) as loose_handle:
                             # It's always a standard file, I get its size
                             loose_size = os.fstat(loose_handle.fileno()).st_size
                             # Determine if I should compress this object or not.
                             # Note: source_compressed is always False because loose objects are always uncompressed
                             # Therefore, it is also true that source_length == source_size
-                            obj_dict["compressed"] = should_compress(
+                            obj_dict['compressed'] = should_compress(
                                 source_stream=loose_handle,
                                 compress_mode=compress_mode,
                                 source_compressed=False,
@@ -1488,12 +1479,12 @@ class Container:  # pylint: disable=too-many-public-methods
                             # The second parameter is `None` since we are not computing the hash
                             # We can instead pass the hash algorithm and assert that it is correct
                             (
-                                obj_dict["size"],
+                                obj_dict['size'],
                                 new_hashkey,
                             ) = self._write_data_to_packfile(
                                 pack_handle=pack_handle,
                                 read_handle=loose_handle,
-                                compress=obj_dict["compressed"],
+                                compress=obj_dict['compressed'],
                                 hash_type=hash_type,
                             )
                     except PermissionError:
@@ -1505,22 +1496,23 @@ class Container:  # pylint: disable=too-many-public-methods
                             f"Error when packing object '{loose_hashkey}': "
                             f"re-computed hash is different! '{new_hashkey}'"
                         )
-                    obj_dict["length"] = pack_handle.tell() - obj_dict["offset"]
+                    obj_dict['length'] = pack_handle.tell() - obj_dict['offset']
 
                     # Appending for later bulk commit - see comments in add_streamed_objects_to_pack
                     obj_dicts.append(obj_dict)
 
                     if callback:
                         callback(
-                            action="update",
-                            value=obj_dict["size"],
+                            action='update',
+                            value=obj_dict['size'],
                         )
                 # It's now time to write to the DB, in a single bulk operation (per pack)
                 if obj_dicts:
                     # Here I shouldn't need to do `OR IGNORE` as in `add_streamed_objects_to_pack`
                     # Because I'm already checking the hash keys and avoiding to add twice the same
                     session.execute(
-                        Obj.__table__.insert(), obj_dicts  # pylint: disable=no-member
+                        Obj.__table__.insert(),
+                        obj_dicts,  # pylint: disable=no-member
                     )
                     # Clean up the list - this will be cleaned up also later,
                     # but it's better to make sure that we do it here, to avoid trying to rewrite
@@ -1551,7 +1543,7 @@ class Container:  # pylint: disable=too-many-public-methods
             # on Mac and on Windows (see issues #37 and #43). Therefore, I do NOT delete them,
             # and deletion is deferred to a manual clean-up operation.
         if callback:
-            callback(action="close", value=None)
+            callback(action='close', value=None)
 
     def add_streamed_object_to_pack(  # pylint: disable=too-many-arguments
         self,
@@ -1645,7 +1637,7 @@ class Container:  # pylint: disable=too-many-public-methods
         """
         assert isinstance(
             compress, bool
-        ), "Only True of False are valid `compress` modes when adding direclty to a pack"
+        ), 'Only True of False are valid `compress` modes when adding direclty to a pack'
         yield_per_size = 1000
         hashkeys: list[str] = []
 
@@ -1661,8 +1653,8 @@ class Container:  # pylint: disable=too-many-public-methods
                 if total:
                     # If we have a callback, compute the total count of objects in this pack
                     callback(
-                        action="init",
-                        value={"total": total, "description": "List existing"},
+                        action='init',
+                        value={'total': total, 'description': 'List existing'},
                     )
                     # Update at most 400 times, avoiding to increase CPU usage; if the list is small: every object.
                     update_every = max(int(total / 400), 1)
@@ -1694,21 +1686,21 @@ class Container:  # pylint: disable=too-many-public-methods
                 if callback:
                     since_last_update += len(results_chunk)
                     if since_last_update >= update_every:
-                        callback(action="update", value=since_last_update)
+                        callback(action='update', value=since_last_update)
                         since_last_update = 0
 
             if callback and total:
                 # Final call to complete the bar
                 if since_last_update:
-                    callback(action="update", value=since_last_update)
+                    callback(action='update', value=since_last_update)
                 # Perform any wrap-up, if needed
-                callback(action="close", value=None)
+                callback(action='close', value=None)
 
         if callback:
             total = len(working_stream_list)
             # If we have a callback, compute the total count of objects in this pack
             callback(
-                action="init", value={"total": total, "description": "Bulk storing"}
+                action='init', value={'total': total, 'description': 'Bulk storing'}
             )
             # Update at most 400 times, avoiding to increase CPU usage; if the list is small: every object.
             update_every = max(int(total / 400), 1)
@@ -1754,7 +1746,7 @@ class Container:  # pylint: disable=too-many-public-methods
                     if callback:
                         since_last_update += 1
                         if since_last_update >= update_every:
-                            callback(action="update", value=since_last_update)
+                            callback(action='update', value=since_last_update)
                             since_last_update = 0
 
                     # Get the position before writing the object - I need it if `no_holes` is True and the object
@@ -1762,22 +1754,22 @@ class Container:  # pylint: disable=too-many-public-methods
                     position_before = pack_handle.tell()
 
                     obj_dict: dict[str, Any] = {}
-                    obj_dict["pack_id"] = pack_int_id
-                    obj_dict["compressed"] = compress
-                    obj_dict["offset"] = pack_handle.tell()
+                    obj_dict['pack_id'] = pack_int_id
+                    obj_dict['compressed'] = compress
+                    obj_dict['offset'] = pack_handle.tell()
                     with stream_context_manager as stream:
                         if no_holes and no_holes_read_twice:
                             # Compute the hash key before writing (I just read once)
                             (
-                                obj_dict["hashkey"],
-                                obj_dict["size"],
+                                obj_dict['hashkey'],
+                                obj_dict['size'],
                             ) = compute_hash_and_size(stream, hash_type=self.hash_type)
-                            if obj_dict["hashkey"] in known_packed_hashkeys:
+                            if obj_dict['hashkey'] in known_packed_hashkeys:
                                 # I recomputed the hashkey and this was already there: I don't try to write on disk,
                                 # but I just continue.
                                 # Note, however, that I first need to append the hash key to the list of
                                 # hash keys to return at the end
-                                hashkeys.append(obj_dict["hashkey"])
+                                hashkeys.append(obj_dict['hashkey'])
                                 continue
                             # I didn't continue. Then, I need to store on disk, as it is a new unknown object.
                             # I therefore need to seek back to zero, because the next line will read it again
@@ -1785,15 +1777,15 @@ class Container:  # pylint: disable=too-many-public-methods
                             stream.seek(0)
 
                         (
-                            obj_dict["size"],
-                            obj_dict["hashkey"],
+                            obj_dict['size'],
+                            obj_dict['hashkey'],
                         ) = self._write_data_to_packfile(
                             pack_handle=pack_handle,
                             read_handle=stream,
                             compress=compress,
                             hash_type=self.hash_type,
                         )
-                    obj_dict["length"] = pack_handle.tell() - obj_dict["offset"]
+                    obj_dict['length'] = pack_handle.tell() - obj_dict['offset']
                     # Here, we have appended the object to the pack file.
                     # And now that we are done, we know the hash key.
                     # However, we have to cope with the fact that an object with the same hash key
@@ -1805,7 +1797,7 @@ class Container:  # pylint: disable=too-many-public-methods
 
                     # In this case, I have in memory a set of hash keys already in packs.
                     # Note that known_packed_hashkeys is defined only if no_holes is True.
-                    if no_holes and obj_dict["hashkey"] in known_packed_hashkeys:
+                    if no_holes and obj_dict['hashkey'] in known_packed_hashkeys:
                         # The object is there!
                         # I seek back; I don't truncate, it's not needed.
                         # I will truncate only at the very end, if needed.
@@ -1824,7 +1816,7 @@ class Container:  # pylint: disable=too-many-public-methods
 
                         # I also add the hash key in the known_packed_hashkeys (if no_holes, when this is defined)
                         if no_holes:
-                            known_packed_hashkeys.add(obj_dict["hashkey"])
+                            known_packed_hashkeys.add(obj_dict['hashkey'])
 
                     # Now, I have two options.
                     # 1. I just leave in the unused bits, and we do a re-packing later.
@@ -1846,7 +1838,7 @@ class Container:  # pylint: disable=too-many-public-methods
                     # end out of space. I would try next 3a, in case.
 
                     # Append the new hash key to the list of hash keys to return
-                    hashkeys.append(obj_dict["hashkey"])
+                    hashkeys.append(obj_dict['hashkey'])
 
                 if no_holes:
                     # If I don't want holes, I might be left in a case where at the end of the pack
@@ -1858,7 +1850,7 @@ class Container:  # pylint: disable=too-many-public-methods
                 if obj_dicts:
                     session.execute(
                         Obj.__table__.insert().prefix_with(  # pylint: disable=no-member
-                            "OR IGNORE"
+                            'OR IGNORE'
                         ),
                         obj_dicts,
                     )
@@ -1888,9 +1880,9 @@ class Container:  # pylint: disable=too-many-public-methods
         if callback:
             # Final call to complete the bar
             if since_last_update:
-                callback(action="update", value=since_last_update)
+                callback(action='update', value=since_last_update)
             # Perform any wrap-up, if needed
-            callback(action="close", value=None)
+            callback(action='close', value=None)
 
         return hashkeys
 
@@ -1931,7 +1923,7 @@ class Container:  # pylint: disable=too-many-public-methods
         """
         if not self.is_initialised:
             raise ValueError(
-                "Invalid use of function, please first initialise the container."
+                'Invalid use of function, please first initialise the container.'
             )
         stream_list: list[StreamSeekBytesType] = [
             io.BytesIO(content) for content in content_list
@@ -1983,7 +1975,7 @@ class Container:  # pylint: disable=too-many-public-methods
 
         assert (
             written_hashkey == hashkey
-        ), "Mismatch in the hashkey when rewriting an existing object as loose! {written_hashkey} vs {hashkey}"
+        ), 'Mismatch in the hashkey when rewriting an existing object as loose! {written_hashkey} vs {hashkey}'
         return self._get_loose_path_from_hashkey(hashkey)
 
     def _vacuum(self) -> None:
@@ -1999,8 +1991,8 @@ class Container:  # pylint: disable=too-many-public-methods
         # VACUUM cannot be performed from within a transaction
         # see: https://github.com/sqlalchemy/sqlalchemy/discussions/6959
         session = self._get_operation_session()
-        session.execute(text("COMMIT"))
-        session.execute(text("VACUUM"))
+        session.execute(text('COMMIT'))
+        session.execute(text('VACUUM'))
         # ensure sqlalchemy knows to open a new transaction for the next execution
         session.commit()
 
@@ -2028,8 +2020,8 @@ class Container:  # pylint: disable=too-many-public-methods
             # I check only duplicates, but I don't delete files that start with a dot
             # (these might have been added by some process scanning the folders or something similar, like
             # .DS_Store on macOS)
-            if "." in duplicate and not duplicate.startswith("."):
-                reference_obj_hashkey = duplicate.partition(".")[0]
+            if '.' in duplicate and not duplicate.startswith('.'):
+                reference_obj_hashkey = duplicate.partition('.')[0]
                 duplicates_mapping[reference_obj_hashkey].append(duplicate)
 
         for reference_obj_hashkey in duplicates_mapping:
@@ -2046,9 +2038,9 @@ class Container:  # pylint: disable=too-many-public-methods
                 # the hash is correct, and put it in the right place as a loose object.
                 raise InconsistentContent(
                     f"There is at least a duplicate for object '{reference_obj_hashkey}' "
-                    "that however does not exist anymore. "
+                    'that however does not exist anymore. '
                     "If you don't need it, use `delete_objects()` passing this hash key to clean up the repository, "
-                    "or attempt a manual recovery of the duplicate"
+                    'or attempt a manual recovery of the duplicate'
                 )
 
             if computed_hash == reference_obj_hashkey:
@@ -2059,7 +2051,7 @@ class Container:  # pylint: disable=too-many-public-methods
                 good_duplicate = None
                 for duplicate in duplicates_mapping[reference_obj_hashkey]:
                     with open(
-                        self._get_duplicates_folder() / duplicate, "rb"
+                        self._get_duplicates_folder() / duplicate, 'rb'
                     ) as fhandle:
                         computed_hash, _ = compute_hash_and_size(
                             fhandle, self.hash_type
@@ -2103,7 +2095,7 @@ class Container:  # pylint: disable=too-many-public-methods
         else:
             sorted_hashkeys = sorted(loose_objects)
             pack_iterator = session.execute(
-                text("SELECT hashkey FROM db_object ORDER BY hashkey")
+                text('SELECT hashkey FROM db_object ORDER BY hashkey')
             )
 
             # The query returns a tuple of length 1, so I still need a left_key
@@ -2167,8 +2159,8 @@ class Container:  # pylint: disable=too-many-public-methods
                 # If we have a callback, compute the total count of objects in this pack
                 total = len(sorted_hashkeys)
                 callback(
-                    action="init",
-                    value={"total": total, "description": "Listing objects"},
+                    action='init',
+                    value={'total': total, 'description': 'Listing objects'},
                 )
                 # Update at most 400 times, avoiding to increase CPU usage; if the list is small: every object.
                 update_every = max(int(total / 1000), 1)
@@ -2187,7 +2179,7 @@ class Container:  # pylint: disable=too-many-public-methods
             # NOTE: I need to wrap in the `yield_first_element` iterator since it returns a list of lists
             sorted_packed = yield_first_element(
                 self._get_operation_session().execute(
-                    text("SELECT hashkey FROM db_object ORDER BY hashkey")
+                    text('SELECT hashkey FROM db_object ORDER BY hashkey')
                 )
             )
             sorted_existing = merge_sorted(sorted_loose, sorted_packed)
@@ -2202,7 +2194,7 @@ class Container:  # pylint: disable=too-many-public-methods
                     # the list of hash keys in this (destination) container. This is probably OK, though.
                     since_last_update += 1
                     if since_last_update >= update_every:
-                        callback(action="update", value=since_last_update)
+                        callback(action='update', value=since_last_update)
                         since_last_update = 0
 
                 if where == Location.LEFTONLY:
@@ -2211,9 +2203,9 @@ class Container:  # pylint: disable=too-many-public-methods
             if callback:
                 # Final call to complete the bar
                 if since_last_update:
-                    callback(action="update", value=since_last_update)
+                    callback(action='update', value=since_last_update)
                 # Perform any wrap-up, if needed
-                callback(action="close", value=None)
+                callback(action='close', value=None)
 
             # I just insert the new objects without first checking that I am not leaving holes in the pack files,
             # as I already checked here.
@@ -2229,7 +2221,7 @@ class Container:  # pylint: disable=too-many-public-methods
             # If we have a callback, compute the total count of objects in this pack
             total = len(hashkeys)
             callback(
-                action="init", value={"total": total, "description": "Copy objects"}
+                action='init', value={'total': total, 'description': 'Copy objects'}
             )
             # Update at most 400 times, avoiding to increase CPU usage; if the list is small: every object.
             update_every = max(int(total / 1000), 1)
@@ -2308,15 +2300,15 @@ class Container:  # pylint: disable=too-many-public-methods
                 if callback:
                     since_last_update += 1
                     if since_last_update >= update_every:
-                        callback(action="update", value=since_last_update)
+                        callback(action='update', value=since_last_update)
                         since_last_update = 0
 
         if callback:
             # Final call to complete the bar
             if since_last_update:
-                callback(action="update", value=since_last_update)
+                callback(action='update', value=since_last_update)
             # Perform any wrap-up, if needed
-            callback(action="close", value=None)
+            callback(action='close', value=None)
 
         # The for loop is finished. I can also go out of the `with` context manager because whatever is in the
         # cache is in memory. Most probably I still have content in the cache, just flush it,
@@ -2333,7 +2325,7 @@ class Container:  # pylint: disable=too-many-public-methods
                 compress=compress,
                 no_holes=no_holes,
                 no_holes_read_twice=no_holes_read_twice,
-                callback=rename_callback(callback, new_description="Final flush"),
+                callback=rename_callback(callback, new_description='Final flush'),
                 do_fsync=do_fsync,
                 # I will commit at the end
                 do_commit=False,
@@ -2431,8 +2423,8 @@ class Container:  # pylint: disable=too-many-public-methods
                 select(func.count()).select_from(Obj).where(Obj.pack_id == pack_id)
             )
             callback(
-                action="init",
-                value={"total": total, "description": f"Pack {pack_id}"},
+                action='init',
+                value={'total': total, 'description': f'Pack {pack_id}'},
             )
             # Update at most 400 times, avoiding to increase CPU usage; if the list is small: every object.
             update_every = max(int(total / 400), 1)
@@ -2443,7 +2435,7 @@ class Container:  # pylint: disable=too-many-public-methods
         # Open the pack only once, read it in order
         pack_path = self._get_pack_path_from_pack_id(str(pack_id))
         current_pos = 0
-        with open(pack_path, mode="rb") as pack_handle:
+        with open(pack_path, mode='rb') as pack_handle:
             stmt = (
                 select(Obj.hashkey, Obj.size, Obj.offset, Obj.length, Obj.compressed)
                 .where(Obj.pack_id == pack_id)
@@ -2478,20 +2470,20 @@ class Container:  # pylint: disable=too-many-public-methods
                 if callback:
                     since_last_update += 1
                     if since_last_update >= update_every:
-                        callback(action="update", value=since_last_update)
+                        callback(action='update', value=since_last_update)
                         since_last_update = 0
 
         if callback:
             # Final call to complete the bar
             if since_last_update:
-                callback(action="update", value=since_last_update)
+                callback(action='update', value=since_last_update)
             # Perform any wrap-up, if needed
-            callback(action="close", value=None)
+            callback(action='close', value=None)
 
         return {
-            "invalid_hashes_packed": invalid_hashes,
-            "invalid_sizes_packed": invalid_sizes,
-            "overlapping_packed": overlapping,
+            'invalid_hashes_packed': invalid_hashes,
+            'invalid_sizes_packed': invalid_sizes,
+            'overlapping_packed': overlapping,
         }
 
     def validate(self, callback: Callable | None = None) -> ValidationIssues:
@@ -2513,20 +2505,20 @@ class Container:  # pylint: disable=too-many-public-methods
 
         if callback:
             callback(
-                action="init",
-                value={"total": len(all_loose), "description": "Loose objects"},
+                action='init',
+                value={'total': len(all_loose), 'description': 'Loose objects'},
             )
 
         for hashkey in all_loose:
-            with open(self._get_loose_path_from_hashkey(hashkey), "rb") as fhandle:
+            with open(self._get_loose_path_from_hashkey(hashkey), 'rb') as fhandle:
                 computed_hash, _ = compute_hash_and_size(fhandle, self.hash_type)
                 if computed_hash != hashkey:
-                    all_errors["invalid_hashes_loose"].append(hashkey)
+                    all_errors['invalid_hashes_loose'].append(hashkey)
                 if callback:
                     # Update for each object
-                    callback(action="update", value=1)
+                    callback(action='update', value=1)
         if callback:
-            callback(action="close", value=None)
+            callback(action='close', value=None)
 
         session = self._get_operation_session()
 
@@ -2589,7 +2581,7 @@ class Container:  # pylint: disable=too-many-public-methods
             duplicates_this_object = [
                 duplicate_fname
                 for duplicate_fname in all_duplicates
-                if duplicate_fname.startswith(f"{hashkey}.")
+                if duplicate_fname.startswith(f'{hashkey}.')
             ]
             for duplicate_fname in duplicates_this_object:
                 # For now I don't put checks - I should be the only one accessing the container, so I should not
@@ -2634,7 +2626,7 @@ class Container:  # pylint: disable=too-many-public-methods
         self,
         compress_mode: CompressMode = CompressMode.KEEP,
         callback: None
-        | (Callable[[Arg(str, "action"), Arg(Any, "value")], None]) = None,
+        | (Callable[[Arg(str, 'action'), Arg(Any, 'value')], None]) = None,
     ) -> None:
         """Perform a repack of all packed objects.
 
@@ -2663,7 +2655,7 @@ class Container:  # pylint: disable=too-many-public-methods
         pack_id: str,
         compress_mode: CompressMode = CompressMode.KEEP,
         callback: None
-        | (Callable[[Arg(str, "action"), Arg(Any, "value")], None]) = None,
+        | (Callable[[Arg(str, 'action'), Arg(Any, 'value')], None]) = None,
     ) -> None:
         """Perform a repack of a given pack object.
 
@@ -2709,16 +2701,16 @@ class Container:  # pylint: disable=too-many-public-methods
         # REPACK_PACK_ID did not exist.
         if callback:
             callback(
-                action="init",
+                action='init',
                 value={
-                    "total": self.get_total_size()["total_size_packed"],
-                    "description": f"Repack {pack_id}",
+                    'total': self.get_total_size()['total_size_packed'],
+                    'description': f'Repack {pack_id}',
                 },
             )
         with self.lock_pack(
             str(self._REPACK_PACK_ID), allow_repack_pack=True
         ) as write_pack_handle:
-            with open(self._get_pack_path_from_pack_id(pack_id), "rb") as read_pack:
+            with open(self._get_pack_path_from_pack_id(pack_id), 'rb') as read_pack:
                 stmt = (
                     select(
                         Obj.id,
@@ -2740,9 +2732,9 @@ class Container:  # pylint: disable=too-many-public-methods
                     source_compressed,
                 ) in session.execute(stmt):
                     # This is the read handle of the bytes in the pack - it might be
-                    read_handle: (
-                        PackedObjectReader | ZlibStreamDecompresser
-                    ) = PackedObjectReader(read_pack, offset, length)
+                    read_handle: PackedObjectReader | ZlibStreamDecompresser = (
+                        PackedObjectReader(read_pack, offset, length)
+                    )
 
                     # Determine if I should compress or not the destination - this function will
                     # try to do it in a cheap way (e.g. if the source is already compressed, will just
@@ -2759,15 +2751,15 @@ class Container:  # pylint: disable=too-many-public-methods
 
                     # Prepare the object for the new entry in the repack-pack
                     obj_dict = {}
-                    obj_dict["id"] = rowid
+                    obj_dict['id'] = rowid
                     # no need to rehash, it's the same object, and we are in the same container, so we are
                     # using the same hashing algorithm
-                    obj_dict["hashkey"] = hashkey
-                    obj_dict["pack_id"] = self._REPACK_PACK_ID
+                    obj_dict['hashkey'] = hashkey
+                    obj_dict['pack_id'] = self._REPACK_PACK_ID
                     # The uncompressed size is the same
-                    obj_dict["size"] = size
-                    obj_dict["compressed"] = dest_compressed
-                    obj_dict["offset"] = write_pack_handle.tell()
+                    obj_dict['size'] = size
+                    obj_dict['compressed'] = dest_compressed
+                    obj_dict['offset'] = write_pack_handle.tell()
 
                     if source_compressed == dest_compressed:
                         # In this branch, we can just transfer the bytes, as we are using the *same* compression
@@ -2779,7 +2771,7 @@ class Container:  # pylint: disable=too-many-public-methods
                         # for now that the mode is KEEP.
                         while True:
                             chunk = read_handle.read(self._CHUNKSIZE)
-                            if chunk == b"":
+                            if chunk == b'':
                                 # Returns an empty bytes object on EOF.
                                 break
                             write_pack_handle.write(chunk)
@@ -2792,7 +2784,7 @@ class Container:  # pylint: disable=too-many-public-methods
                             compressobj = self._get_compressobj_instance()
                             while True:
                                 chunk = read_handle.read(self._CHUNKSIZE)
-                                if chunk == b"":
+                                if chunk == b'':
                                     # Returns an empty bytes object on EOF.
                                     break
                                 write_pack_handle.write(compressobj.compress(chunk))
@@ -2802,18 +2794,18 @@ class Container:  # pylint: disable=too-many-public-methods
                         else:
                             while True:
                                 chunk = read_handle.read(self._CHUNKSIZE)
-                                if chunk == b"":
+                                if chunk == b'':
                                     # Returns an empty bytes object on EOF.
                                     break
                                 write_pack_handle.write(chunk)
 
                     # Set correctly the length on disk
-                    obj_dict["length"] = write_pack_handle.tell() - obj_dict["offset"]
+                    obj_dict['length'] = write_pack_handle.tell() - obj_dict['offset']
                     # Appending for later bulk commit
                     # I will assume that all objects of a single pack fit in memory
                     obj_dicts.append(obj_dict)
                     if callback:
-                        callback(action="update", value=obj_dict["size"])
+                        callback(action='update', value=obj_dict['size'])
             # safe flush to disk seems to be a time consuming operation, but no easy way to include in the progress bar
             safe_flush_to_disk(
                 write_pack_handle,
@@ -2822,7 +2814,7 @@ class Container:  # pylint: disable=too-many-public-methods
                 ),
             )
         if callback:
-            callback(action="close", value=None)
+            callback(action='close', value=None)
         # We are done with data transfer.
         # At this stage we just have a new pack -1 (_REPACK_PACK_ID) but it is never referenced.
         # Let us store the information in the DB.

--- a/disk_objectstore/database.py
+++ b/disk_objectstore/database.py
@@ -1,4 +1,5 @@
 """Models for the container index file (SQLite DB)."""
+
 from pathlib import Path
 
 from sqlalchemy import Boolean, Column, Integer, String, create_engine, event
@@ -12,7 +13,7 @@ Base = declarative_base()  # pylint: disable=invalid-name,useless-suppression
 class Obj(Base):  # pylint: disable=too-few-public-methods
     """The main (and only) table to store object metadata (hashkey, offset, length, ...)."""
 
-    __tablename__ = "db_object"
+    __tablename__ = 'db_object'
 
     id = Column(Integer, primary_key=True)  # pylint: disable=invalid-name
 
@@ -36,13 +37,13 @@ def get_session(path: Path, create: bool = False) -> Session:
     :param create: if True, creates the sqlite file and schema.
     """
     if not create and not path.exists():
-        raise FileNotFoundError("Pack index does not exist")
+        raise FileNotFoundError('Pack index does not exist')
 
-    engine = create_engine(f"sqlite:///{path}", future=True)
+    engine = create_engine(f'sqlite:///{path}', future=True)
 
     # For the next two bindings, see background on
     # https://docs.sqlalchemy.org/en/13/dialects/sqlite.html#serializable-isolation-savepoints-transactional-ddl
-    @event.listens_for(engine, "connect")
+    @event.listens_for(engine, 'connect')
     def do_connect(dbapi_connection, _):
         """Hook function that is called upon connection.
 
@@ -60,15 +61,15 @@ def get_session(path: Path, create: bool = False) -> Session:
         # so you need to close and reload the session to see the newly written data.
         # Docs on WAL: https://www.sqlite.org/wal.html
         cursor = dbapi_connection.cursor()
-        cursor.execute("PRAGMA journal_mode=wal;")
+        cursor.execute('PRAGMA journal_mode=wal;')
         cursor.close()
 
     # For this binding, see background on
     # https://docs.sqlalchemy.org/en/13/dialects/sqlite.html#serializable-isolation-savepoints-transactional-ddl
-    @event.listens_for(engine, "begin")
+    @event.listens_for(engine, 'begin')
     def do_begin(conn):  # pylint: disable=unused-variable
         # emit our own BEGIN
-        conn.execute(text("BEGIN"))
+        conn.execute(text('BEGIN'))
 
     if create:
         # Create all tables in the engine. This is equivalent to "Create Table"

--- a/disk_objectstore/database.py
+++ b/disk_objectstore/database.py
@@ -21,14 +21,10 @@ class Obj(Base):  # pylint: disable=too-few-public-methods
     # If you really do not want a uniqueness field, you will need to adapt the code.
     hashkey = Column(String, nullable=False, unique=True, index=True)
     compressed = Column(Boolean, nullable=False)
-    size = Column(
-        Integer, nullable=False
-    )  # uncompressed size; if uncompressed, size == length
+    size = Column(Integer, nullable=False)  # uncompressed size; if uncompressed, size == length
     offset = Column(Integer, nullable=False)
     length = Column(Integer, nullable=False)
-    pack_id = Column(
-        Integer, nullable=False
-    )  # integer ID of the pack in which this entry is stored
+    pack_id = Column(Integer, nullable=False)  # integer ID of the pack in which this entry is stored
 
 
 def get_session(path: Path, create: bool = False) -> Session:
@@ -81,8 +77,6 @@ def get_session(path: Path, create: bool = False) -> Session:
     Base.metadata.bind = engine
 
     # We set autoflush = False to avoid to lock the DB if just doing queries/reads
-    session = sessionmaker(
-        bind=engine, autoflush=False, autocommit=False, future=True
-    )()
+    session = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)()
 
     return session

--- a/disk_objectstore/dataclasses.py
+++ b/disk_objectstore/dataclasses.py
@@ -2,6 +2,7 @@
 Definition of the dataclasses used as return values of
 a number of methods.
 """
+
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, List, Optional, Union
 
@@ -50,7 +51,7 @@ class ObjectMeta:
         Set to `None` if `type` is not `packed`.
     """
 
-    type: "ObjectType"
+    type: 'ObjectType'
     size: Optional[int]
     pack_id: Optional[str]
     pack_compressed: Optional[bool]

--- a/disk_objectstore/examples/example_objectstore.py
+++ b/disk_objectstore/examples/example_objectstore.py
@@ -37,12 +37,8 @@ from disk_objectstore import Container
     is_flag=True,
     help='Clear the repository path folder before starting.',
 )
-@click.option(
-    '-B', '--num-bulk-calls', default=10, help='Number of bulk calls to get the files.'
-)
-@click.option(
-    '-z', '--compress-packs', is_flag=True, help='Compress objects while packing.'
-)
+@click.option('-B', '--num-bulk-calls', default=10, help='Number of bulk calls to get the files.')
+@click.option('-z', '--compress-packs', is_flag=True, help='Compress objects while packing.')
 @click.option(
     '-P',
     '--profile-file',
@@ -75,9 +71,7 @@ def main(
     files = {}
 
     start_counts = container.count_objects()
-    print(
-        f"Currently known objects: {start_counts['packed']} packed, {start_counts['loose']} loose"
-    )
+    print(f"Currently known objects: {start_counts['packed']} packed, {start_counts['loose']} loose")
     print('Pack objects on disk:', start_counts['pack_files'])
 
     print(f'Generating {num_files} files in memory...')
@@ -87,9 +81,7 @@ def main(
         content = os.urandom(size)
         files[filename] = content
     total_size = sum(len(content) for content in files.values())
-    print(
-        f'Done. Total size: {total_size} bytes (~{total_size // 1024 / 1024:.3f} MB).'
-    )
+    print(f'Done. Total size: {total_size} bytes (~{total_size // 1024 / 1024:.3f} MB).')
 
     if directly_to_pack:
         # Store objects (directly to pack)
@@ -99,9 +91,7 @@ def main(
         hashkeys = container.add_objects_to_pack(files_content, compress=compress_packs)
         hashkey_mapping = dict(zip(filenames, hashkeys))
         tot_time = time.time() - start
-        print(
-            f'Time to store {num_files} objects DIRECTLY TO THE PACKS: {tot_time:.4} s'
-        )
+        print(f'Time to store {num_files} objects DIRECTLY TO THE PACKS: {tot_time:.4} s')
 
         # Check that no loose files were created
         counts = container.count_objects()
@@ -137,9 +127,7 @@ def main(
 
         # Check that the content is correct
         for filename, item in retrieved.items():
-            assert (
-                item == files[filename]
-            ), f'Mismatch (content) for {filename}, {item!r} vs {files[filename]!r}'
+            assert item == files[filename], f'Mismatch (content) for {filename}, {item!r} vs {files[filename]!r}'
 
         # Check that num_files new loose files are present now
         counts = container.count_objects()
@@ -208,9 +196,7 @@ def main(
     start = time.time()
 
     if profile_file is not None:
-        func = profile(sort='cumtime', filename=profile_file, stdout=False)(
-            bulk_read_data
-        )
+        func = profile(sort='cumtime', filename=profile_file, stdout=False)(bulk_read_data)
     else:
         func = bulk_read_data
     raw_retrieved = func(container=container, hashkey_list=all_hashkeys)
@@ -218,12 +204,8 @@ def main(
         print(f"You can check the profiling results running 'snakeviz {profile_file}'")
 
     tot_time = time.time() - start
-    print(
-        f'Time to retrieve {num_files} packed objects in random order WITH ONE BULK CALL: {tot_time} s'
-    )
-    retrieved = {
-        reverse_hashkey_mapping[key]: val for key, val in raw_retrieved.items()
-    }
+    print(f'Time to retrieve {num_files} packed objects in random order WITH ONE BULK CALL: {tot_time} s')
+    retrieved = {reverse_hashkey_mapping[key]: val for key, val in raw_retrieved.items()}
     for filename in retrieved:
         assert retrieved[filename] == files[filename], f'Mismatch for {filename}'
 
@@ -238,24 +220,15 @@ def main(
     chunk_len = len(all_hashkeys) // num_bulk_calls
     if len(all_hashkeys) % num_bulk_calls != 0:
         chunk_len += 1
-    split_iterator = (
-        all_hashkeys[start : start + chunk_len]
-        for start in range(0, len(all_hashkeys), chunk_len)
-    )
+    split_iterator = (all_hashkeys[start : start + chunk_len] for start in range(0, len(all_hashkeys), chunk_len))
 
     # Retrieve in num_bulk_call chunks
     for chunk_of_hashkeys in split_iterator:
-        raw_retrieved.update(
-            container.get_objects_content(chunk_of_hashkeys, skip_if_missing=False)
-        )
+        raw_retrieved.update(container.get_objects_content(chunk_of_hashkeys, skip_if_missing=False))
 
     tot_time = time.time() - start
-    print(
-        f'Time to retrieve {num_files} packed objects in random order WITH {num_bulk_calls} BULK CALLS: {tot_time} s'
-    )
-    retrieved = {
-        reverse_hashkey_mapping[key]: val for key, val in raw_retrieved.items()
-    }
+    print(f'Time to retrieve {num_files} packed objects in random order WITH {num_bulk_calls} BULK CALLS: {tot_time} s')
+    retrieved = {reverse_hashkey_mapping[key]: val for key, val in raw_retrieved.items()}
     for filename in retrieved:
         assert retrieved[filename] == files[filename], f'Mismatch for {filename}'
 
@@ -272,9 +245,7 @@ def main(
     print(f'Time to retrieve {num_files} packed objects in random order: {tot_time} s')
 
     for filename, content in retrieved.items():
-        assert (
-            content == files[filename]
-        ), f'Mismatch (content) for {filename}, {content!r} vs {files[filename]!r}'
+        assert content == files[filename], f'Mismatch (content) for {filename}, {content!r} vs {files[filename]!r}'
 
     print('All tests passed')
 

--- a/disk_objectstore/examples/example_objectstore.py
+++ b/disk_objectstore/examples/example_objectstore.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """A simple implementation with some testing to showcase the functionality and to run some benchmarks."""
+
 import dataclasses
 import os
 import random
@@ -15,40 +16,40 @@ from disk_objectstore import Container
 @click.command(
     context_settings=dict(show_default=True)  # pylint: disable=use-dict-literal
 )
-@click.option("-n", "--num-files", default=100, help="Number of files to create.")
-@click.option("-m", "--min-size", default=0, help="Minimum file size (bytes).")
-@click.option("-M", "--max-size", default=1000, help="Maximum file size (bytes).")
+@click.option('-n', '--num-files', default=100, help='Number of files to create.')
+@click.option('-m', '--min-size', default=0, help='Minimum file size (bytes).')
+@click.option('-M', '--max-size', default=1000, help='Maximum file size (bytes).')
 @click.option(
-    "-d",
-    "--directly-to-pack",
+    '-d',
+    '--directly-to-pack',
     is_flag=True,
-    help="Add directly files to the packs rather than as loose objects.",
+    help='Add directly files to the packs rather than as loose objects.',
 )
 @click.option(
-    "-p",
-    "--path",
-    default="/tmp/test-container",
-    help="The path to a test folder in which the container will be created.",
+    '-p',
+    '--path',
+    default='/tmp/test-container',
+    help='The path to a test folder in which the container will be created.',
 )
 @click.option(
-    "-c",
-    "--clear",
+    '-c',
+    '--clear',
     is_flag=True,
-    help="Clear the repository path folder before starting.",
+    help='Clear the repository path folder before starting.',
 )
 @click.option(
-    "-B", "--num-bulk-calls", default=10, help="Number of bulk calls to get the files."
+    '-B', '--num-bulk-calls', default=10, help='Number of bulk calls to get the files.'
 )
 @click.option(
-    "-z", "--compress-packs", is_flag=True, help="Compress objects while packing."
+    '-z', '--compress-packs', is_flag=True, help='Compress objects while packing.'
 )
 @click.option(
-    "-P",
-    "--profile-file",
+    '-P',
+    '--profile-file',
     default=None,
-    help="Perform the bulk read with profiling and output results onto this file name.",
+    help='Perform the bulk read with profiling and output results onto this file name.',
 )
-@click.help_option("-h", "--help")
+@click.help_option('-h', '--help')
 def main(
     num_files,
     min_size,
@@ -65,10 +66,10 @@ def main(
 
     container = Container(path)
     if clear:
-        print("Clearing the container...")
+        print('Clearing the container...')
         container.init_container(clear=clear)
     if not container.is_initialised:
-        print("Initialising the container...")
+        print('Initialising the container...')
         container.init_container()
 
     files = {}
@@ -77,17 +78,17 @@ def main(
     print(
         f"Currently known objects: {start_counts['packed']} packed, {start_counts['loose']} loose"
     )
-    print("Pack objects on disk:", start_counts["pack_files"])
+    print('Pack objects on disk:', start_counts['pack_files'])
 
-    print(f"Generating {num_files} files in memory...")
+    print(f'Generating {num_files} files in memory...')
     for _ in range(num_files):
-        filename = f"filename-{str(uuid.uuid4())}"
+        filename = f'filename-{uuid.uuid4()!s}'
         size = random.randint(min_size, max_size)
         content = os.urandom(size)
         files[filename] = content
     total_size = sum(len(content) for content in files.values())
     print(
-        f"Done. Total size: {total_size} bytes (~{total_size // 1024 / 1024:.3f} MB)."
+        f'Done. Total size: {total_size} bytes (~{total_size // 1024 / 1024:.3f} MB).'
     )
 
     if directly_to_pack:
@@ -99,13 +100,13 @@ def main(
         hashkey_mapping = dict(zip(filenames, hashkeys))
         tot_time = time.time() - start
         print(
-            f"Time to store {num_files} objects DIRECTLY TO THE PACKS: {tot_time:.4} s"
+            f'Time to store {num_files} objects DIRECTLY TO THE PACKS: {tot_time:.4} s'
         )
 
         # Check that no loose files were created
         counts = container.count_objects()
         assert (
-            counts["loose"] == start_counts["loose"]
+            counts['loose'] == start_counts['loose']
         ), f"Mismatch (loose in packed case): {start_counts['loose']} != {counts['loose']}"
         ## Cannot do this with the hash key implenentation - I might have stored the same object twice
         # assert counts['packed'
@@ -120,7 +121,7 @@ def main(
             obj_hashkey = container.add_object(content)
             hashkey_mapping[filename] = obj_hashkey
         tot_time = time.time() - start
-        print(f"Time to store {num_files} loose objects: {tot_time:.4} s")
+        print(f'Time to store {num_files} loose objects: {tot_time:.4} s')
 
         # Retrieve objects (loose)
         retrieved = {}
@@ -132,13 +133,13 @@ def main(
             retrieved_content = container.get_object_content(obj_hashkey)
             retrieved[filename] = retrieved_content
         tot_time = time.time() - start
-        print(f"Time to retrieve {num_files} loose objects: {tot_time:.4} s")
+        print(f'Time to retrieve {num_files} loose objects: {tot_time:.4} s')
 
         # Check that the content is correct
         for filename, item in retrieved.items():
             assert (
                 item == files[filename]
-            ), f"Mismatch (content) for {filename}, {item!r} vs {files[filename]!r}"
+            ), f'Mismatch (content) for {filename}, {item!r} vs {files[filename]!r}'
 
         # Check that num_files new loose files are present now
         counts = container.count_objects()
@@ -150,24 +151,24 @@ def main(
 
         # Print container size info (before packing)
         size_info = container.get_total_size()
-        print("Object store size info:")
+        print('Object store size info:')
         for key in sorted(dataclasses.asdict(size_info).keys()):
-            print(f"- {key:30s}: {size_info[key]}")
+            print(f'- {key:30s}: {size_info[key]}')
 
         # Pack all loose objects
         start = time.time()
         container.pack_all_loose(compress=compress_packs)
         tot_time = time.time() - start
-        print(f"Time to pack all loose objects: {tot_time:.4} s")
+        print(f'Time to pack all loose objects: {tot_time:.4} s')
         start = time.time()
         container.clean_storage()
         tot_time = time.time() - start
-        print(f"Time to clean storage: {tot_time:.4} s")
+        print(f'Time to clean storage: {tot_time:.4} s')
 
         # Check that all loose files are gone
         counts = container.count_objects()
         loose_folder = container._get_loose_folder()  # pylint: disable=protected-access
-        assert not counts["loose"], "loose objects left: " f"{os.listdir(loose_folder)}"
+        assert not counts['loose'], 'loose objects left: ' f'{os.listdir(loose_folder)}'
         ## I cannot do this because I could have overlap if the object is identical and has the same hash key
         # assert counts['packed'] == start_counts['packed'] + start_counts[
         #    'loose'] + num_files, 'Mismatch (post-pack): {} + {} + {} != {}'.format(
@@ -176,9 +177,9 @@ def main(
 
     # print container size info
     size_info = container.get_total_size()
-    print("Object store size info:")
+    print('Object store size info:')
     for key in sorted(dataclasses.asdict(size_info).keys()):
-        print(f"- {key:30s}: {size_info[key]}")
+        print(f'- {key:30s}: {size_info[key]}')
 
     # In all cases, retrieve all objects (in shuffled order)
     retrieved = {}
@@ -207,7 +208,7 @@ def main(
     start = time.time()
 
     if profile_file is not None:
-        func = profile(sort="cumtime", filename=profile_file, stdout=False)(
+        func = profile(sort='cumtime', filename=profile_file, stdout=False)(
             bulk_read_data
         )
     else:
@@ -218,13 +219,13 @@ def main(
 
     tot_time = time.time() - start
     print(
-        f"Time to retrieve {num_files} packed objects in random order WITH ONE BULK CALL: {tot_time} s"
+        f'Time to retrieve {num_files} packed objects in random order WITH ONE BULK CALL: {tot_time} s'
     )
     retrieved = {
         reverse_hashkey_mapping[key]: val for key, val in raw_retrieved.items()
     }
     for filename in retrieved:
-        assert retrieved[filename] == files[filename], f"Mismatch for {filename}"
+        assert retrieved[filename] == files[filename], f'Mismatch for {filename}'
 
     ########################################
     # SECOND: num_bulk_calls bulk reads
@@ -250,13 +251,13 @@ def main(
 
     tot_time = time.time() - start
     print(
-        f"Time to retrieve {num_files} packed objects in random order WITH {num_bulk_calls} BULK CALLS: {tot_time} s"
+        f'Time to retrieve {num_files} packed objects in random order WITH {num_bulk_calls} BULK CALLS: {tot_time} s'
     )
     retrieved = {
         reverse_hashkey_mapping[key]: val for key, val in raw_retrieved.items()
     }
     for filename in retrieved:
-        assert retrieved[filename] == files[filename], f"Mismatch for {filename}"
+        assert retrieved[filename] == files[filename], f'Mismatch for {filename}'
 
     ########################################
     # THIRD: a lot of independent reads, one per object
@@ -268,15 +269,15 @@ def main(
         retrieved_content = container.get_object_content(obj_hashkey)
         retrieved[filename] = retrieved_content
     tot_time = time.time() - start
-    print(f"Time to retrieve {num_files} packed objects in random order: {tot_time} s")
+    print(f'Time to retrieve {num_files} packed objects in random order: {tot_time} s')
 
     for filename, content in retrieved.items():
         assert (
             content == files[filename]
-        ), f"Mismatch (content) for {filename}, {content!r} vs {files[filename]!r}"
+        ), f'Mismatch (content) for {filename}, {content!r} vs {files[filename]!r}'
 
-    print("All tests passed")
+    print('All tests passed')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()  # pylint: disable=no-value-for-parameter

--- a/disk_objectstore/examples/profile_zeros.py
+++ b/disk_objectstore/examples/profile_zeros.py
@@ -4,6 +4,7 @@
 This checks the performance (can be run with profiling as well) and can be used to check
 that in streaming mode, even when dealing with very large data, the memory usage is always
 limited."""
+
 # pylint: disable=too-many-arguments
 import dataclasses
 import time
@@ -18,11 +19,11 @@ from disk_objectstore.utils import ZeroStream
 
 def get_memory():
     """Get memory info on the current process."""
-    full_info = psutil.Process().as_dict(attrs=["memory_full_info"])["memory_full_info"]
+    full_info = psutil.Process().as_dict(attrs=['memory_full_info'])['memory_full_info']
     return {
-        "rss": full_info.rss,
-        "vms": full_info.vms,
-        "uss": full_info.uss,
+        'rss': full_info.rss,
+        'vms': full_info.vms,
+        'uss': full_info.uss,
     }
 
 
@@ -34,7 +35,7 @@ def main_run(container, size_gb, compress_packs):
     print(
         f"Currently known objects: {start_counts['packed']} packed, {start_counts['loose']} loose"
     )
-    print("Pack objects on disk:", start_counts["pack_files"])
+    print('Pack objects on disk:', start_counts['pack_files'])
 
     zero_stream = ZeroStream(length=size_bytes)
     start = time.time()
@@ -43,22 +44,22 @@ def main_run(container, size_gb, compress_packs):
         stream_list=[zero_stream], compress=compress_packs
     )[0]
     tot_time = time.time() - start
-    print(f"Time to store one file of zeros of size {size_gb} GB: {tot_time:.4} s")
+    print(f'Time to store one file of zeros of size {size_gb} GB: {tot_time:.4} s')
 
     # Check that no loose files were created
     counts = container.count_objects()
     assert (
-        counts["loose"] == start_counts["loose"]
+        counts['loose'] == start_counts['loose']
     ), f"Mismatch (loose in packed case): {start_counts['loose']} != {counts['loose']}"
     assert (
-        counts["packed"] == start_counts["packed"] + 1
+        counts['packed'] == start_counts['packed'] + 1
     ), f"Mismatch (packed in packed case): {start_counts['packed']} + 1 != {counts['packed']}"
 
     # print container size info
     size_info = container.get_total_size()
-    print("Object store size info:")
+    print('Object store size info:')
     for key in sorted(dataclasses.asdict(size_info).keys()):
-        print(f"- {key:30s}: {size_info[key]}")
+        print(f'- {key:30s}: {size_info[key]}')
 
     # Retrieve the object (if it's too small (a few KB) it's slow)
     chunk_size = 16 * 1024 * 1024
@@ -75,44 +76,44 @@ def main_run(container, size_gb, compress_packs):
                 break
 
     tot_time = time.time() - start
-    print(f"Time to retrieve 1 packed object of size {size_gb} GB: {tot_time} s")
+    print(f'Time to retrieve 1 packed object of size {size_gb} GB: {tot_time} s')
 
     assert size_bytes == num_bytes_retrieved
     # assert md5_beginning == md5_retrieved
 
-    print("All tests passed")
+    print('All tests passed')
 
 
 @click.command()
-@click.option("-s", "--size-gb", default=1, help="File size in GB.")
+@click.option('-s', '--size-gb', default=1, help='File size in GB.')
 @click.option(
-    "-p",
-    "--path",
-    default="/tmp/test-container",
-    help="The path to a test folder in which the container will be created.",
+    '-p',
+    '--path',
+    default='/tmp/test-container',
+    help='The path to a test folder in which the container will be created.',
 )
 @click.option(
-    "-c",
-    "--clear",
+    '-c',
+    '--clear',
     is_flag=True,
-    help="Clear the repository path folder before starting.",
+    help='Clear the repository path folder before starting.',
 )
 @click.option(
-    "-m",
-    "--check-memory-measurement",
+    '-m',
+    '--check-memory-measurement',
     is_flag=True,
-    help="Perform various additional memory measurements.",
+    help='Perform various additional memory measurements.',
 )
 @click.option(
-    "-l",
-    "--with-line-profiler",
+    '-l',
+    '--with-line-profiler',
     is_flag=True,
-    help="When profiling memory, also run a line profiler.",
+    help='When profiling memory, also run a line profiler.',
 )
 @click.option(
-    "-z", "--compress-packs", is_flag=True, help="Compress objects while packing."
+    '-z', '--compress-packs', is_flag=True, help='Compress objects while packing.'
 )
-@click.help_option("-h", "--help")
+@click.help_option('-h', '--help')
 def main(
     size_gb, path, clear, check_memory_measurement, with_line_profiler, compress_packs
 ):
@@ -125,38 +126,38 @@ def main(
         # Test of memory allocation
         size_mb = 400
         size = size_mb * 1024 * 1024
-        temp_array = b"\x00" * size  #  noqa: F841
+        temp_array = b'\x00' * size
 
-        print("*" * 74)
-        print(f"AFTER CREATING AN ARRAY of {size_mb} MBs:")
+        print('*' * 74)
+        print(f'AFTER CREATING AN ARRAY of {size_mb} MBs:')
         end_mem = get_memory()
         for key, end_value in end_mem.items():
             start_value = start_mem[key]
             print(
-                f"{key}: {start_value} -> {end_value} "
-                f"(DELTA = {end_value - start_value} = "
-                f"{(end_value - start_value) / 1024.0 / 1024.0:.2f} MB)"
+                f'{key}: {start_value} -> {end_value} '
+                f'(DELTA = {end_value - start_value} = '
+                f'{(end_value - start_value) / 1024.0 / 1024.0:.2f} MB)'
             )
         del temp_array
 
-        print("*" * 74)
-        print("AFTER DELETING THE ARRAY:")
+        print('*' * 74)
+        print('AFTER DELETING THE ARRAY:')
         end_mem = get_memory()
         for key, end_value in end_mem.items():
             start_value = start_mem[key]
             print(
-                f"{key}: {start_value} -> {end_value} "
-                f"(DELTA = {end_value - start_value} = "
-                f"{(end_value - start_value) / 1024.0 / 1024.0:.2f} MB)"
+                f'{key}: {start_value} -> {end_value} '
+                f'(DELTA = {end_value - start_value} = '
+                f'{(end_value - start_value) / 1024.0 / 1024.0:.2f} MB)'
             )
-        print("*" * 74)
+        print('*' * 74)
 
     container = Container(path)
     if clear:
-        print("Clearing the container...")
+        print('Clearing the container...')
         container.init_container(clear=clear)
     if not container.is_initialised:
-        print("Initialising the container...")
+        print('Initialising the container...')
         container.init_container()
 
     function = profile(main_run) if with_line_profiler else main_run
@@ -168,20 +169,18 @@ def main(
                 function,
                 tuple(),
                 {
-                    "container": container,
-                    "size_gb": size_gb,
-                    "compress_packs": compress_packs,
+                    'container': container,
+                    'size_gb': size_gb,
+                    'compress_packs': compress_packs,
                 },
             ),
             interval=memory_check_interval,
         )
         # Check that it's not an empty list
-        assert (
-            memory_report
-        ), f">> Process too fast for checking memory usage with interval {memory_check_interval} s!!!"
+        assert memory_report, f'>> Process too fast for checking memory usage with interval {memory_check_interval} s!!!'
         print(
-            f">> Max memory usage (check interval {memory_check_interval} s, "
-            f"{len(memory_report)} checks performed): {max(memory_report):.3f} MB"
+            f'>> Max memory usage (check interval {memory_check_interval} s, '
+            f'{len(memory_report)} checks performed): {max(memory_report):.3f} MB'
         )
     else:
         function(container=container, size_gb=size_gb, compress_packs=compress_packs)
@@ -190,11 +189,11 @@ def main(
     for key, end_value in end_mem.items():
         start_value = start_mem[key]
         print(
-            f"{key}: {start_value} -> {end_value} "
-            f"(DELTA = {end_value - start_value} = "
-            f"{(end_value - start_value) / 1024.0 / 1024.0:.2f} MB)"
+            f'{key}: {start_value} -> {end_value} '
+            f'(DELTA = {end_value - start_value} = '
+            f'{(end_value - start_value) / 1024.0 / 1024.0:.2f} MB)'
         )
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()  # pylint: disable=no-value-for-parameter

--- a/disk_objectstore/examples/profile_zeros.py
+++ b/disk_objectstore/examples/profile_zeros.py
@@ -32,17 +32,13 @@ def main_run(container, size_gb, compress_packs):
     size_bytes = size_gb * 1024 * 1024 * 1024
 
     start_counts = container.count_objects()
-    print(
-        f"Currently known objects: {start_counts['packed']} packed, {start_counts['loose']} loose"
-    )
+    print(f"Currently known objects: {start_counts['packed']} packed, {start_counts['loose']} loose")
     print('Pack objects on disk:', start_counts['pack_files'])
 
     zero_stream = ZeroStream(length=size_bytes)
     start = time.time()
     # Store objects (directly to pack)
-    obj_hashkey = container.add_streamed_objects_to_pack(
-        stream_list=[zero_stream], compress=compress_packs
-    )[0]
+    obj_hashkey = container.add_streamed_objects_to_pack(stream_list=[zero_stream], compress=compress_packs)[0]
     tot_time = time.time() - start
     print(f'Time to store one file of zeros of size {size_gb} GB: {tot_time:.4} s')
 
@@ -110,19 +106,13 @@ def main_run(container, size_gb, compress_packs):
     is_flag=True,
     help='When profiling memory, also run a line profiler.',
 )
-@click.option(
-    '-z', '--compress-packs', is_flag=True, help='Compress objects while packing.'
-)
+@click.option('-z', '--compress-packs', is_flag=True, help='Compress objects while packing.')
 @click.help_option('-h', '--help')
-def main(
-    size_gb, path, clear, check_memory_measurement, with_line_profiler, compress_packs
-):
+def main(size_gb, path, clear, check_memory_measurement, with_line_profiler, compress_packs):
     """Testing performance and size on disk when storing a single big file containing only zeros."""
     start_mem = get_memory()
 
-    if (
-        check_memory_measurement
-    ):  # To test that the measurement of the memory is reliable
+    if check_memory_measurement:  # To test that the measurement of the memory is reliable
         # Test of memory allocation
         size_mb = 400
         size = size_mb * 1024 * 1024
@@ -177,7 +167,9 @@ def main(
             interval=memory_check_interval,
         )
         # Check that it's not an empty list
-        assert memory_report, f'>> Process too fast for checking memory usage with interval {memory_check_interval} s!!!'
+        assert (
+            memory_report
+        ), f'>> Process too fast for checking memory usage with interval {memory_check_interval} s!!!'
         print(
             f'>> Max memory usage (check interval {memory_check_interval} s, '
             f'{len(memory_report)} checks performed): {max(memory_report):.3f} MB'

--- a/disk_objectstore/utils.py
+++ b/disk_objectstore/utils.py
@@ -3,6 +3,7 @@
 Some might be useful also for end users, like the wrappers to get streams,
 like the ``LazyOpener``.
 """
+
 #  pylint: disable= too-many-lines
 from __future__ import annotations
 
@@ -40,7 +41,7 @@ try:
 
     # Next line exists only on Mac, will be 0 otherwise
     # (Just to have an int, will never be used not on Mac)
-    F_FULLFSYNC = getattr(fcntl, "F_FULLFSYNC", 0)
+    F_FULLFSYNC = getattr(fcntl, 'F_FULLFSYNC', 0)
 except ImportError:
     # Not available on Windows
     fcntl = None  # type: ignore
@@ -50,17 +51,17 @@ except ImportError:
 # requires read method only
 StreamReadBytesType = Union[
     BinaryIO,
-    "PackedObjectReader",
-    "CallbackStreamWrapper",
-    "ZlibLikeBaseStreamDecompresser",
-    "ZeroStream",
+    'PackedObjectReader',
+    'CallbackStreamWrapper',
+    'ZlibLikeBaseStreamDecompresser',
+    'ZeroStream',
 ]
 # requires read and seek capability
 StreamSeekBytesType = Union[
     BinaryIO,
-    "PackedObjectReader",
-    "CallbackStreamWrapper",
-    "ZlibLikeBaseStreamDecompresser",
+    'PackedObjectReader',
+    'CallbackStreamWrapper',
+    'ZlibLikeBaseStreamDecompresser',
 ]
 StreamWriteBytesType = BinaryIO
 
@@ -78,13 +79,13 @@ class CompressMode(Enum):
     """
 
     # Never compress
-    NO = "no"  # pylint: disable=invalid-name
+    NO = 'no'  # pylint: disable=invalid-name
     # Always recompress
-    YES = "yes"
+    YES = 'yes'
     # Keep the current compression when repacking.
-    KEEP = "keep"
+    KEEP = 'keep'
     # Automatically determine if it's worth compressing this object or not, ideally in a relatively efficient way.
-    AUTO = "auto"
+    AUTO = 'auto'
 
 
 class Location(Enum):
@@ -116,9 +117,9 @@ class LazyOpener:
         return self._path
 
     @property
-    def mode(self) -> Literal["rb"]:
+    def mode(self) -> Literal['rb']:
         """The file open mode."""
-        return "rb"
+        return 'rb'
 
     def tell(self) -> int:
         """Return the position in the underlying file object.
@@ -127,7 +128,7 @@ class LazyOpener:
         :raises ValueError: if the file is not open.
         """
         if self._fhandle is None:
-            raise ValueError("I/O operation on closed file.")
+            raise ValueError('I/O operation on closed file.')
         return self._fhandle.tell()
 
     def __enter__(self) -> BinaryIO:
@@ -136,7 +137,7 @@ class LazyOpener:
         Note: you cannot open it twice with two with statements.
         """
         if self._fhandle is not None:
-            raise OSError(f"File {self.path} already open")
+            raise OSError(f'File {self.path} already open')
         self._fhandle = open(self.path, mode=self.mode)
         return self._fhandle
 
@@ -169,7 +170,7 @@ class LazyLooseStream:
 
     @property
     def mode(self) -> str:
-        return "rb"
+        return 'rb'
 
     @staticmethod
     def seekable() -> bool:
@@ -182,10 +183,10 @@ class LazyLooseStream:
         Note that contrary to a standard file, also seeking beyond the borders will raise a ValueError.
         """
         if self.closed:
-            raise ValueError("I/O operation on closed file.")
+            raise ValueError('I/O operation on closed file.')
         assert self._stream is not None, (
-            "LazyLooseStream has an open stream, but the stream is None! "
-            "This should not happen"
+            'LazyLooseStream has an open stream, but the stream is None! '
+            'This should not happen'
         )
 
         return self._stream.seek(target, whence)
@@ -193,10 +194,10 @@ class LazyLooseStream:
     def tell(self) -> int:
         """Return current stream position, relative to the internal offset."""
         if self.closed:
-            raise ValueError("I/O operation on closed file.")
+            raise ValueError('I/O operation on closed file.')
         assert self._stream is not None, (
-            "LazyLooseStream has an open stream, but the stream is None! "
-            "This should not happen"
+            'LazyLooseStream has an open stream, but the stream is None! '
+            'This should not happen'
         )
         return self._stream.tell()
 
@@ -211,10 +212,10 @@ class LazyLooseStream:
         Returns an empty bytes object on EOF.
         """
         if self.closed:
-            raise ValueError("I/O operation on closed file.")
+            raise ValueError('I/O operation on closed file.')
         assert self._stream is not None, (
-            "LazyLooseStream has an open stream, but the stream is None! "
-            "This should not happen"
+            'LazyLooseStream has an open stream, but the stream is None! '
+            'This should not happen'
         )
         return self._stream.read(size)
 
@@ -242,7 +243,7 @@ class LazyLooseStream:
             loose_path = self._container.loosen_object(self._hashkey)
             try:
                 self._stream = open(  # pylint: disable=consider-using-with
-                    loose_path, mode="rb"
+                    loose_path, mode='rb'
                 )
                 # I could open the stream, exit the infinite loop
                 break
@@ -253,10 +254,10 @@ class LazyLooseStream:
                 counter += 1
                 if counter > MAX_RETRIES:
                     raise RuntimeError(
-                        "Unable to open the loose object! I tried multiple "
-                        "times but I never find the file. Ensure that you are "
-                        "not running many concurrent cleaning of the container "
-                        "storage."
+                        'Unable to open the loose object! I tried multiple '
+                        'times but I never find the file. Ensure that you are '
+                        'not running many concurrent cleaning of the container '
+                        'storage.'
                     ) from exc
 
     def close_stream(self) -> None:
@@ -335,7 +336,7 @@ class ObjectWriter:  # pylint: disable=too-many-instance-attributes
         :note: Do not close the file, it will be closed automatically.
         """
         if self._filehandle is not None:
-            raise OSError("You have already opened this ObjectWriter instance")
+            raise OSError('You have already opened this ObjectWriter instance')
         if self._stored:
             raise ModificationNotAllowed(
                 f"You have already tried to store this object '{self.get_hashkey()}'"
@@ -344,7 +345,7 @@ class ObjectWriter:  # pylint: disable=too-many-instance-attributes
         # It seems faster than using a NamedTemporaryFile, see benchmarks.
         self._obj_path = self._sandbox_folder / uuid.uuid4().hex
         self._filehandle = HashWriterWrapper(
-            open(self._obj_path, "wb"), hash_type=self.hash_type
+            open(self._obj_path, 'wb'), hash_type=self.hash_type
         )
         return self._filehandle
 
@@ -360,7 +361,7 @@ class ObjectWriter:  # pylint: disable=too-many-instance-attributes
                 assert self._filehandle is not None and self._obj_path is not None
                 if self._filehandle.closed:
                     raise ClosingNotAllowed(
-                        "You cannot close the file handle yourself!"
+                        'You cannot close the file handle yourself!'
                     )
                 # Flush out of the buffer and sync to disk so data is preserved even for power failures
                 # NOTE: For now I don't use `fullsync` on Mac for performance reasons, for loose objects - to decide
@@ -495,7 +496,7 @@ class ObjectWriter:  # pylint: disable=too-many-instance-attributes
                 # https://blog.gocept.com/2013/07/15/reliable-file-updates-with-python/
                 # I do not call safe_flush_to_disk as I need to flush only the folder metadata (I think)
                 # Otherwise I should open again the file
-                if os.name == "posix":
+                if os.name == 'posix':
                     dirfd = os.open(dest_parent_folder.parent, os.O_DIRECTORY)
                     os.fsync(dirfd)
                     os.close(dirfd)
@@ -515,7 +516,7 @@ class ObjectWriter:  # pylint: disable=too-many-instance-attributes
         """
         # Destination file starts with the hashkey, then has an dot as a separator, and is
         # followed by un UUID to make sure there is never a collision
-        dest_file = self._duplicates_folder / f"{hashkey}.{uuid.uuid4().hex}"
+        dest_file = self._duplicates_folder / f'{hashkey}.{uuid.uuid4().hex}'
         os.rename(source_file, dest_file)
 
 
@@ -535,8 +536,8 @@ class PackedObjectReader:
         :param length: the integer length of the byte stream.
           The read() method will ensure that you never go beyond the given length.
         """
-        assert "b" in fhandle.mode
-        assert "r" in fhandle.mode
+        assert 'b' in fhandle.mode
+        assert 'r' in fhandle.mode
 
         self._fhandle = fhandle
         self._offset = offset
@@ -562,7 +563,7 @@ class PackedObjectReader:
         """
         if whence not in [0, 1, 2]:
             raise ValueError(
-                "Invalid value for `whence`: only 0, 1 and 2 are currently implemented."
+                'Invalid value for `whence`: only 0, 1 and 2 are currently implemented.'
             )
 
         if whence in [0, 1]:
@@ -571,11 +572,11 @@ class PackedObjectReader:
 
             if target < 0:
                 raise ValueError(
-                    "specified target would exceed the lower boundary of bytes that are accessible."
+                    'specified target would exceed the lower boundary of bytes that are accessible.'
                 )
             if target > self._length:
                 raise ValueError(
-                    "specified target would exceed the upper boundary of bytes that are accessible."
+                    'specified target would exceed the upper boundary of bytes that are accessible.'
                 )
             new_pos = self._offset + target
         else:
@@ -652,7 +653,7 @@ class CallbackStreamWrapper:
         stream: StreamSeekBytesType,
         callback: Callable | None,
         total_length: int = 0,
-        description: str = "Streamed object",
+        description: str = 'Streamed object',
     ) -> None:
         """
         Initialises the reader to a given stream.
@@ -674,7 +675,7 @@ class CallbackStreamWrapper:
         if self._callback:
             # If we have a callback, compute the total count of objects in this pack
             self._callback(
-                action="init", value={"total": total_length, "description": description}
+                action='init', value={'total': total_length, 'description': description}
             )
 
     @property
@@ -691,23 +692,23 @@ class CallbackStreamWrapper:
             if self._callback:
                 self._since_last_update = self._since_last_update + target - self.tell()
                 if self._since_last_update >= self._update_every:
-                    self._callback(action="update", value=self._since_last_update)
+                    self._callback(action='update', value=self._since_last_update)
                     self._since_last_update = 0
         else:
             self.close_callback()
             if self._callback:
                 # If we have a callback, compute the total count of objects in this pack
                 self._callback(
-                    action="init",
+                    action='init',
                     value={
-                        "total": self._total_length,
-                        "description": f"{self._description} [rewind]",
+                        'total': self._total_length,
+                        'description': f'{self._description} [rewind]',
                     },
                 )
                 # Counter of how many objects have been since since the last update.
                 # A new callback will be performed when this value is > update_every.
                 self._since_last_update = target
-                self._callback(action="update", value=self._since_last_update)
+                self._callback(action='update', value=self._since_last_update)
 
         return self._stream.seek(target, whence)
 
@@ -730,7 +731,7 @@ class CallbackStreamWrapper:
         if self._callback:
             self._since_last_update += len(data)
             if self._since_last_update >= self._update_every:
-                self._callback(action="update", value=self._since_last_update)
+                self._callback(action='update', value=self._since_last_update)
                 self._since_last_update = 0
 
         return data
@@ -751,9 +752,9 @@ class CallbackStreamWrapper:
         if self._callback:
             # Final call to complete the bar
             if self._since_last_update:
-                self._callback(action="update", value=self._since_last_update)
+                self._callback(action='update', value=self._since_last_update)
             # Perform any wrap-up, if needed
-            self._callback(action="close", value=None)
+            self._callback(action='close', value=None)
 
 
 def rename_callback(callback: Callable | None, new_description: str) -> Callable | None:
@@ -769,9 +770,9 @@ def rename_callback(callback: Callable | None, new_description: str) -> Callable
 
     def wrapper_callback(action, value):
         """A wrapper callback with changed description."""
-        if action == "init":
+        if action == 'init':
             new_value = value.copy()
-            new_value["description"] = new_description
+            new_value['description'] = new_description
             return callback(action, new_value)  # type: ignore
         return callback(action, value)  # type: ignore
 
@@ -807,7 +808,7 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
         """
         self._compressed_stream = compressed_stream
         self._decompressor = self.decompressobj_class()
-        self._internal_buffer = b""
+        self._internal_buffer = b''
         self._pos = 0
         self._lazy_uncompressed_stream: None | (
             LazyLooseStream
@@ -818,7 +819,7 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
 
     @property
     def mode(self) -> str:
-        return getattr(self._compressed_stream, "mode", "rb")
+        return getattr(self._compressed_stream, 'mode', 'rb')
 
     def read(self, size: int = -1) -> bytes:
         """
@@ -828,8 +829,8 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
         # don't use anymore the compressed one.
         if self._use_uncompressed_stream:
             assert self._lazy_uncompressed_stream is not None, (
-                "Using internally an uncompressed stream, but it is None! "
-                "This should not happen"
+                'Using internally an uncompressed stream, but it is None! '
+                'This should not happen'
             )
             return self._lazy_uncompressed_stream.read(size)
         return self._read_compressed(size)
@@ -863,10 +864,10 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
                     break
                 data.append(next_chunk)
             # Making a list and joining does many less mallocs, so should be faster
-            return b"".join(data)
+            return b''.join(data)
 
         if size == 0:
-            return b""
+            return b''
 
         while len(self._internal_buffer) < size:
             old_unconsumed = self._decompressor.unconsumed_tail
@@ -885,7 +886,7 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
                     compressed_chunk, size
                 )
             except self.decompress_error as exc:
-                raise ValueError("Error while uncompressing data") from exc
+                raise ValueError('Error while uncompressing data') from exc
             self._internal_buffer += decompressed_chunk
 
             if not next_chunk and not self._decompressor.unconsumed_tail:
@@ -895,7 +896,7 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
                     break
                 raise ValueError(
                     "There is no data in the reading buffer, but we didn't reach the end of "
-                    "the compressed stream: there must be a problem in the incoming buffer"
+                    'the compressed stream: there must be a problem in the incoming buffer'
                 )
 
         # Note that we could be here also with len(self._internal_buffer) < size,
@@ -940,8 +941,8 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
         """Return current position in file."""
         if self._use_uncompressed_stream:
             assert self._lazy_uncompressed_stream is not None, (
-                "Using internally an uncompressed stream, but it is None! "
-                "This should not happen"
+                'Using internally an uncompressed stream, but it is None! '
+                'This should not happen'
             )
             return self._lazy_uncompressed_stream.tell()
         return self._pos
@@ -959,7 +960,7 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
         # the very start.
         if whence not in [0, 1, 2]:
             raise ValueError(
-                "Invalid value for `whence`: only 0, 1 and 2 are valid values."
+                'Invalid value for `whence`: only 0, 1 and 2 are valid values.'
             )
         # If we didn't switch to the uncompressed stream
         # but we are asking for a potential random-access position
@@ -1017,8 +1018,8 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
         # If we are using the uncompressed stream, I just proxy the request
         if self._use_uncompressed_stream:
             assert self._lazy_uncompressed_stream is not None, (
-                "Using internally an uncompressed stream, but it is None! "
-                "This should not happen"
+                'Using internally an uncompressed stream, but it is None! '
+                'This should not happen'
             )
             return self._lazy_uncompressed_stream.seek(target, whence)
 
@@ -1027,16 +1028,16 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
             target = self.tell() + target
         if whence == 2:
             raise NotImplementedError(
-                "Cannot seek backwards for a compressed stream without container support"
+                'Cannot seek backwards for a compressed stream without container support'
             )
 
         if target < 0:
-            raise ValueError(f"negative seek position {target}")
+            raise ValueError(f'negative seek position {target}')
         if target == 0:
             # Going back to zero it's efficient. I need to reset all internal variables, as in the init.
             self._compressed_stream.seek(0)
             self._decompressor = self.decompressobj_class()
-            self._internal_buffer = b""
+            self._internal_buffer = b''
             self._pos = 0
             return 0
 
@@ -1073,15 +1074,15 @@ class ZlibStreamDecompresser(ZlibLikeBaseStreamDecompresser):
 def _get_compression_algorithm_info(algorithm: str):
     """Return a compresser and a decompresser for the given algorithm."""
     known_algorithms = {
-        "zlib": {
-            "compressobj": zlib.compressobj,
-            "variant_name": "level",
-            "variant_mapper": {str(i): i for i in range(1, 10)},  # from 1 to 9
-            "decompresser": ZlibStreamDecompresser,
+        'zlib': {
+            'compressobj': zlib.compressobj,
+            'variant_name': 'level',
+            'variant_mapper': {str(i): i for i in range(1, 10)},  # from 1 to 9
+            'decompresser': ZlibStreamDecompresser,
         }
     }
 
-    algorithm_name, _, variant = algorithm.partition("+")
+    algorithm_name, _, variant = algorithm.partition('+')
     try:
         algorithm_info = known_algorithms[algorithm_name]
     except KeyError:
@@ -1091,16 +1092,16 @@ def _get_compression_algorithm_info(algorithm: str):
         )
     try:
         kwargs = {
-            algorithm_info["variant_name"]: algorithm_info["variant_mapper"][variant]  # type: ignore
+            algorithm_info['variant_name']: algorithm_info['variant_mapper'][variant]  # type: ignore
         }
-        compresser = algorithm_info["compressobj"](**kwargs)  # type: ignore
+        compresser = algorithm_info['compressobj'](**kwargs)  # type: ignore
     except KeyError:
         # pylint: disable=raise-missing-from
         raise ValueError(
             f"Invalid variant '{variant}' for compression algorithm '{algorithm_name}'"
         )
 
-    decompresser = algorithm_info["decompresser"]
+    decompresser = algorithm_info['decompresser']
 
     return compresser, decompresser
 
@@ -1139,7 +1140,7 @@ class ZeroStream:
 
     @property
     def mode(self) -> str:
-        return "rb"
+        return 'rb'
 
     def read(self, size: int = -1) -> bytes:
         """
@@ -1156,13 +1157,13 @@ class ZeroStream:
         remaining_bytes = self._length - self._pos
 
         if size is None or size < 0:
-            stream = b"\x00" * remaining_bytes
+            stream = b'\x00' * remaining_bytes
             self._pos += remaining_bytes
             return stream
 
         # Get the requested bytes, but at most the remaining_bytes
         bytes_to_fetch = min(remaining_bytes, size)
-        stream = b"\x00" * bytes_to_fetch
+        stream = b'\x00' * bytes_to_fetch
         self._pos += bytes_to_fetch
         return stream
 
@@ -1178,7 +1179,7 @@ def is_known_hash(hash_type: str) -> bool:
 
 def get_hash_cls(hash_type: str) -> Callable:
     """Return a hash class with an update method and a hexdigest method."""
-    known_hashes = {"sha1": hashlib.sha1, "sha256": hashlib.sha256}
+    known_hashes = {'sha1': hashlib.sha1, 'sha256': hashlib.sha256}
 
     try:
         return known_hashes[hash_type]
@@ -1200,7 +1201,7 @@ def _compute_hash_for_file(filepath: Path, hash_type: str) -> str | None:
 
     hasher = get_hash_cls(hash_type)()
     try:
-        with open(filepath, "rb") as fhandle:
+        with open(filepath, 'rb') as fhandle:
             while True:
                 chunk = fhandle.read(_chunksize)
                 hasher.update(chunk)
@@ -1226,7 +1227,7 @@ class HashWriterWrapper:
            be also passed to a hashlib implementation to compute the hash.
         """
         self._write_stream = write_stream
-        assert "b" in self._write_stream.mode
+        assert 'b' in self._write_stream.mode
         self._hash_type = hash_type
 
         self._hash = get_hash_cls(self._hash_type)()
@@ -1250,9 +1251,9 @@ class HashWriterWrapper:
         # written to disk (e.g. a first chunk of bytes, and then the disk became full).
         # We want to make sure we are computing the correct hash.
         assert self._position == self._write_stream.tell(), (
-            f"Error in the position ({self._position} vs {self._write_stream.tell()}), "
-            "possibly an error occurred in a previous `write` call. "
-            "This HashWriterMapper object is invalid and should not be used anymore"
+            f'Error in the position ({self._position} vs {self._write_stream.tell()}), '
+            'possibly an error occurred in a previous `write` call. '
+            'This HashWriterMapper object is invalid and should not be used anymore'
         )
 
         self._write_stream.write(data)
@@ -1326,14 +1327,12 @@ def safe_flush_to_disk(
     fhandle.flush()
 
     # Default fsync function, replaced on Mac OS X
-    _fsync_function: Callable[
-        [Any], Any
-    ] = lambda fileno: os.fsync(  # pylint: disable=unnecessary-lambda
+    _fsync_function: Callable[[Any], Any] = lambda fileno: os.fsync(  # pylint: disable=unnecessary-lambda
         fileno
     )
 
     # Flush to disk
-    if hasattr(fcntl, "F_FULLFSYNC") is not None and (
+    if hasattr(fcntl, 'F_FULLFSYNC') is not None and (
         _MACOS_ALWAYS_USE_FULLSYNC or use_fullsync
     ):
         # This exists only on Mac OS X; See e.g. (link split on two lines, put them together):
@@ -1347,11 +1346,9 @@ def safe_flush_to_disk(
         # > should use F_FULLFSYNC to ensure that their data is written in the order
         # > they expect.  Please see fcntl(2) for more detail.
         # Replace the _fsync_function
-        _fsync_function = (
-            lambda fileno: fcntl.fcntl(  # pylint: disable=unnecessary-lambda-assignment
-                fileno,
-                F_FULLFSYNC,
-            )
+        _fsync_function = lambda fileno: fcntl.fcntl(  # pylint: disable=unnecessary-lambda-assignment
+            fileno,
+            F_FULLFSYNC,
         )
     else:
         # In general this is the function to call
@@ -1359,7 +1356,7 @@ def safe_flush_to_disk(
 
     # Flush also the parent directory on posix, see e.g.
     # https://blog.gocept.com/2013/07/15/reliable-file-updates-with-python/
-    if os.name == "posix":
+    if os.name == 'posix':
         dirfd = os.open(real_path.parent, os.O_DIRECTORY)
         # Also here call the correct fsync function
         _fsync_function(dirfd)
@@ -1451,37 +1448,34 @@ def detect_where_sorted(  # pylint: disable=too-many-branches, too-many-statemen
         if now_left:
             if right_exhausted:
                 yield last_left, Location.LEFTONLY
+            elif left_key(last_left) == last_right:
+                # They are equal: add to intersection and continue
+                yield last_left, Location.BOTH
+                # I need to consume and advance on both iterators at the next iteration
+                advance_both = True
+            elif left_key(last_left) < last_right:
+                # the new entry (last_left) is still smaller: it's on the left only
+                yield last_left, Location.LEFTONLY
             else:
-                if left_key(last_left) == last_right:
-                    # They are equal: add to intersection and continue
-                    yield last_left, Location.BOTH
-                    # I need to consume and advance on both iterators at the next iteration
-                    advance_both = True
-                elif left_key(last_left) < last_right:
-                    # the new entry (last_left) is still smaller: it's on the left only
-                    yield last_left, Location.LEFTONLY
-                else:
-                    # the new entry (last_left) is now larger: then, last_right is only on the right
-                    # and I switch to now_right
-                    yield last_right, Location.RIGHTONLY
-                    now_left = False
-        else:
-            if left_exhausted:
+                # the new entry (last_left) is now larger: then, last_right is only on the right
+                # and I switch to now_right
                 yield last_right, Location.RIGHTONLY
-            else:
-                if left_key(last_left) == last_right:
-                    # They are equal: add to intersection and continue
-                    yield last_left, Location.BOTH
-                    # I need to consume and advance on both iterators at the next iteration
-                    advance_both = True
-                elif left_key(last_left) > last_right:
-                    # the new entry (last_right) is still smaller: it's on the right only
-                    yield last_right, Location.RIGHTONLY
-                else:
-                    # the new entry (last_right) is now larger: then, last_left is only on the left
-                    # and I switch to now_left
-                    yield last_left, Location.LEFTONLY
-                    now_left = True
+                now_left = False
+        elif left_exhausted:
+            yield last_right, Location.RIGHTONLY
+        elif left_key(last_left) == last_right:
+            # They are equal: add to intersection and continue
+            yield last_left, Location.BOTH
+            # I need to consume and advance on both iterators at the next iteration
+            advance_both = True
+        elif left_key(last_left) > last_right:
+            # the new entry (last_right) is still smaller: it's on the right only
+            yield last_right, Location.RIGHTONLY
+        else:
+            # the new entry (last_right) is now larger: then, last_left is only on the left
+            # and I switch to now_left
+            yield last_left, Location.LEFTONLY
+            now_left = True
 
         # When we are here: if now_left, then last_left has been inserted in one of the lists;
         # if not now_left, then last_right has been insterted in one of the lists.
@@ -1495,7 +1489,7 @@ def detect_where_sorted(  # pylint: disable=too-many-branches, too-many-statemen
                 new = next(left_iterator)
                 if left_key(new) <= left_key(last_left):
                     raise ValueError(
-                        "The left iterator does not return sorted unique entries, "
+                        'The left iterator does not return sorted unique entries, '
                         f"I got '{left_key(new)}' after '{left_key(last_left)}'"
                     )
                 last_left = new
@@ -1593,7 +1587,7 @@ def should_compress(
         # Estimate the amount of compression we can get and decide whether to compress based on how much we can save.
         compression_ratio = estimate_compression(source_stream, source_size)
         return compression_ratio < compression_threshold
-    raise NotImplementedError(f"Unknown {compress_mode=}")
+    raise NotImplementedError(f'Unknown {compress_mode=}')
 
 
 def estimate_compression(stream: StreamSeekBytesType, size: int) -> float:
@@ -1646,8 +1640,8 @@ def estimate_compression(stream: StreamSeekBytesType, size: int) -> float:
     # I just want to know if it's compressible, I compress with some cheap ZLIB version,
     # Ideally this gives me a good estimate. Probably I could even do better, e.g. like BTRFS I
     # could estimate Shannon's entropy
-    compresser = get_compressobj_instance("zlib+1")
-    compressed = compresser.compress(b"".join(sampled_data))
+    compresser = get_compressobj_instance('zlib+1')
+    compressed = compresser.compress(b''.join(sampled_data))
     compressed += compresser.flush()
 
     # Since I have a guard above for small-size files, I never get here for

--- a/disk_objectstore/utils.py
+++ b/disk_objectstore/utils.py
@@ -185,8 +185,7 @@ class LazyLooseStream:
         if self.closed:
             raise ValueError('I/O operation on closed file.')
         assert self._stream is not None, (
-            'LazyLooseStream has an open stream, but the stream is None! '
-            'This should not happen'
+            'LazyLooseStream has an open stream, but the stream is None! ' 'This should not happen'
         )
 
         return self._stream.seek(target, whence)
@@ -196,8 +195,7 @@ class LazyLooseStream:
         if self.closed:
             raise ValueError('I/O operation on closed file.')
         assert self._stream is not None, (
-            'LazyLooseStream has an open stream, but the stream is None! '
-            'This should not happen'
+            'LazyLooseStream has an open stream, but the stream is None! ' 'This should not happen'
         )
         return self._stream.tell()
 
@@ -214,8 +212,7 @@ class LazyLooseStream:
         if self.closed:
             raise ValueError('I/O operation on closed file.')
         assert self._stream is not None, (
-            'LazyLooseStream has an open stream, but the stream is None! '
-            'This should not happen'
+            'LazyLooseStream has an open stream, but the stream is None! ' 'This should not happen'
         )
         return self._stream.read(size)
 
@@ -338,15 +335,11 @@ class ObjectWriter:  # pylint: disable=too-many-instance-attributes
         if self._filehandle is not None:
             raise OSError('You have already opened this ObjectWriter instance')
         if self._stored:
-            raise ModificationNotAllowed(
-                f"You have already tried to store this object '{self.get_hashkey()}'"
-            )
+            raise ModificationNotAllowed(f"You have already tried to store this object '{self.get_hashkey()}'")
         # Create a new uniquely-named file in the sandbox.
         # It seems faster than using a NamedTemporaryFile, see benchmarks.
         self._obj_path = self._sandbox_folder / uuid.uuid4().hex
-        self._filehandle = HashWriterWrapper(
-            open(self._obj_path, 'wb'), hash_type=self.hash_type
-        )
+        self._filehandle = HashWriterWrapper(open(self._obj_path, 'wb'), hash_type=self.hash_type)
         return self._filehandle
 
     def __exit__(  # pylint: disable=too-many-branches, too-many-statements
@@ -360,9 +353,7 @@ class ObjectWriter:  # pylint: disable=too-many-instance-attributes
             if exc_type is None:
                 assert self._filehandle is not None and self._obj_path is not None
                 if self._filehandle.closed:
-                    raise ClosingNotAllowed(
-                        'You cannot close the file handle yourself!'
-                    )
+                    raise ClosingNotAllowed('You cannot close the file handle yourself!')
                 # Flush out of the buffer and sync to disk so data is preserved even for power failures
                 # NOTE: For now I don't use `fullsync` on Mac for performance reasons, for loose objects - to decide
                 # if we want to change this!
@@ -372,9 +363,7 @@ class ObjectWriter:  # pylint: disable=too-many-instance-attributes
                 self._filehandle = None
 
                 if self._loose_prefix_len:
-                    parent_folder = (
-                        self._loose_folder / self._hashkey[: self._loose_prefix_len]
-                    )
+                    parent_folder = self._loose_folder / self._hashkey[: self._loose_prefix_len]
                     # Create parent folder the first time; done with try/except
                     # rather than with if/else to avoid problems at the beginning, for concurrent writing
                     try:
@@ -409,9 +398,7 @@ class ObjectWriter:  # pylint: disable=too-many-instance-attributes
                     # be wrong. But this is very difficult to catch, and in general
                     # the situation in which a process writes a corrupt node is really an error
                     try:
-                        existing_checksum = _compute_hash_for_file(
-                            filepath=dest_loose_object, hash_type=self.hash_type
-                        )
+                        existing_checksum = _compute_hash_for_file(filepath=dest_loose_object, hash_type=self.hash_type)
                     except PermissionError:
                         # On Windows I might get a PermissionError. I store a copy and return.
                         # This would happen if e.g. the file exists but is being moved in place and
@@ -562,22 +549,16 @@ class PackedObjectReader:
         Note that contrary to a standard file, also seeking beyond the borders will raise a ValueError.
         """
         if whence not in [0, 1, 2]:
-            raise ValueError(
-                'Invalid value for `whence`: only 0, 1 and 2 are currently implemented.'
-            )
+            raise ValueError('Invalid value for `whence`: only 0, 1 and 2 are currently implemented.')
 
         if whence in [0, 1]:
             if whence == 1:
                 target = self.tell() + target
 
             if target < 0:
-                raise ValueError(
-                    'specified target would exceed the lower boundary of bytes that are accessible.'
-                )
+                raise ValueError('specified target would exceed the lower boundary of bytes that are accessible.')
             if target > self._length:
-                raise ValueError(
-                    'specified target would exceed the upper boundary of bytes that are accessible.'
-                )
+                raise ValueError('specified target would exceed the upper boundary of bytes that are accessible.')
             new_pos = self._offset + target
         else:
             # Seek relative to the end
@@ -674,9 +655,7 @@ class CallbackStreamWrapper:
         self._since_last_update: int = 0
         if self._callback:
             # If we have a callback, compute the total count of objects in this pack
-            self._callback(
-                action='init', value={'total': total_length, 'description': description}
-            )
+            self._callback(action='init', value={'total': total_length, 'description': description})
 
     @property
     def mode(self) -> str:
@@ -810,9 +789,7 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
         self._decompressor = self.decompressobj_class()
         self._internal_buffer = b''
         self._pos = 0
-        self._lazy_uncompressed_stream: None | (
-            LazyLooseStream
-        ) = lazy_uncompressed_stream
+        self._lazy_uncompressed_stream: None | (LazyLooseStream) = lazy_uncompressed_stream
         # If True, this class just proxies request to the underlying
         # uncompressed stream
         self._use_uncompressed_stream: bool = False
@@ -829,8 +806,7 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
         # don't use anymore the compressed one.
         if self._use_uncompressed_stream:
             assert self._lazy_uncompressed_stream is not None, (
-                'Using internally an uncompressed stream, but it is None! '
-                'This should not happen'
+                'Using internally an uncompressed stream, but it is None! ' 'This should not happen'
             )
             return self._lazy_uncompressed_stream.read(size)
         return self._read_compressed(size)
@@ -871,9 +847,7 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
 
         while len(self._internal_buffer) < size:
             old_unconsumed = self._decompressor.unconsumed_tail
-            next_chunk = self._compressed_stream.read(
-                max(0, self._CHUNKSIZE - len(old_unconsumed))
-            )
+            next_chunk = self._compressed_stream.read(max(0, self._CHUNKSIZE - len(old_unconsumed)))
 
             # In the previous step, I might have some leftover data
             # since I am using the max_size parameter of .decompress()
@@ -882,9 +856,7 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
             # not need more than `size` bytes. Leftovers will be left in
             # .unconsumed_tail and reused a the next loop
             try:
-                decompressed_chunk = self._decompressor.decompress(
-                    compressed_chunk, size
-                )
+                decompressed_chunk = self._decompressor.decompress(compressed_chunk, size)
             except self.decompress_error as exc:
                 raise ValueError('Error while uncompressing data') from exc
             self._internal_buffer += decompressed_chunk
@@ -941,8 +913,7 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
         """Return current position in file."""
         if self._use_uncompressed_stream:
             assert self._lazy_uncompressed_stream is not None, (
-                'Using internally an uncompressed stream, but it is None! '
-                'This should not happen'
+                'Using internally an uncompressed stream, but it is None! ' 'This should not happen'
             )
             return self._lazy_uncompressed_stream.tell()
         return self._pos
@@ -959,9 +930,7 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
         # to the slow option or re-decompressing everything from
         # the very start.
         if whence not in [0, 1, 2]:
-            raise ValueError(
-                'Invalid value for `whence`: only 0, 1 and 2 are valid values.'
-            )
+            raise ValueError('Invalid value for `whence`: only 0, 1 and 2 are valid values.')
         # If we didn't switch to the uncompressed stream
         # but we are asking for a potential random-access position
         # we ask to materialize/open the uncompressed stream, and switch to it.
@@ -977,16 +946,8 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
         # it cannot deal with (e.g. whence = 2) and raise, or accept that in this
         # case some operations will be (much) slower, potentially requiring to
         # re-decompress the file when seeking backwards.
-        should_uncompress = (
-            whence == 2
-            or (whence == 1 and target < 0)
-            or (whence == 1 and target < self._pos)
-        )
-        if (
-            not self._use_uncompressed_stream
-            and self._lazy_uncompressed_stream is not None
-            and should_uncompress
-        ):
+        should_uncompress = whence == 2 or (whence == 1 and target < 0) or (whence == 1 and target < self._pos)
+        if not self._use_uncompressed_stream and self._lazy_uncompressed_stream is not None and should_uncompress:
             # Request to open the uncompressed stream.
             # From now on, this class will directly proxy
             # tell/seek requests to the uncompressed stream
@@ -1018,8 +979,7 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
         # If we are using the uncompressed stream, I just proxy the request
         if self._use_uncompressed_stream:
             assert self._lazy_uncompressed_stream is not None, (
-                'Using internally an uncompressed stream, but it is None! '
-                'This should not happen'
+                'Using internally an uncompressed stream, but it is None! ' 'This should not happen'
             )
             return self._lazy_uncompressed_stream.seek(target, whence)
 
@@ -1027,9 +987,7 @@ class ZlibLikeBaseStreamDecompresser(abc.ABC):
         if whence == 1:
             target = self.tell() + target
         if whence == 2:
-            raise NotImplementedError(
-                'Cannot seek backwards for a compressed stream without container support'
-            )
+            raise NotImplementedError('Cannot seek backwards for a compressed stream without container support')
 
         if target < 0:
             raise ValueError(f'negative seek position {target}')
@@ -1087,9 +1045,7 @@ def _get_compression_algorithm_info(algorithm: str):
         algorithm_info = known_algorithms[algorithm_name]
     except KeyError:
         # pylint: disable=raise-missing-from)
-        raise ValueError(
-            f"Unknown or unsupported compression algorithm '{algorithm_name}'"
-        )
+        raise ValueError(f"Unknown or unsupported compression algorithm '{algorithm_name}'")
     try:
         kwargs = {
             algorithm_info['variant_name']: algorithm_info['variant_mapper'][variant]  # type: ignore
@@ -1097,9 +1053,7 @@ def _get_compression_algorithm_info(algorithm: str):
         compresser = algorithm_info['compressobj'](**kwargs)  # type: ignore
     except KeyError:
         # pylint: disable=raise-missing-from
-        raise ValueError(
-            f"Invalid variant '{variant}' for compression algorithm '{algorithm_name}'"
-        )
+        raise ValueError(f"Invalid variant '{variant}' for compression algorithm '{algorithm_name}'")
 
     decompresser = algorithm_info['decompresser']
 
@@ -1332,9 +1286,7 @@ def safe_flush_to_disk(
     )
 
     # Flush to disk
-    if hasattr(fcntl, 'F_FULLFSYNC') is not None and (
-        _MACOS_ALWAYS_USE_FULLSYNC or use_fullsync
-    ):
+    if hasattr(fcntl, 'F_FULLFSYNC') is not None and (_MACOS_ALWAYS_USE_FULLSYNC or use_fullsync):
         # This exists only on Mac OS X; See e.g. (link split on two lines, put them together):
         # https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/
         #          man2/fsync.2.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,9 +85,43 @@ exclude = [
 line-length = 120
 fail-on-change = true
 
-[tool.isort]
-profile = 'black'
-src_paths = ['disk_objectstore', 'tests']
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.format]
+quote-style = 'single'
+
+[tool.ruff.lint]
+ignore = [
+  'F403',  # Star imports unable to detect undefined names
+  'F405',  # Import may be undefined or defined from star imports
+  'PLR0911',  # Too many return statements
+  'PLR0912',  # Too many branches
+  'PLR0913',  # Too many arguments in function definition
+  'PLR0915',  # Too many statements
+  'PLR2004',  # Magic value used in comparison
+  'RUF005',  # Consider iterable unpacking instead of concatenation
+  'RUF012',  # Mutable class attributes should be annotated with `typing.ClassVar`
+  'N802', # Function name should be lowercase
+  'N806', # Variable in functions should be always loweercase
+  'N818', # Exception should be named with an Error suffix
+  'E731', # Do not assign a lambda expression, use a def
+  'RUF015', # Use next(iter(...))) for iteration over single element
+  'PLC0206', # Extracting value from dictionary without calling `.items()`
+  'PLW0602', # Using global without assignment
+]
+select = [
+  'E',  # pydocstyle
+  'W',  # pydocstyle
+  'F',  # pyflakes
+  'I',  # isort
+  'N',  # pep8-naming
+  'PLC',  # pylint-convention
+  'PLE',  # pylint-error
+  'PLR',  # pylint-refactor
+  'PLW',  # pylint-warning
+  'RUF'  # ruff
+]
 
 [tool.mypy]
 show_error_codes = true
@@ -95,24 +129,6 @@ check_untyped_defs = true
 scripts_are_modules = true
 warn_redundant_casts = true
 plugins = ['sqlalchemy.ext.mypy.plugin']
-
-[tool.pylint.format]
-max-line-length = 120
-max-args = 6
-
-[tool.pylint.messages_control]
-disable = [
-    'duplicate-code',
-    'too-few-public-methods',
-    'unspecified-encoding'
-]
-
-[tool.pylint.basic]
-good-names = []
-docstring-min-length = 5
-
-[tool.pylint.design]
-max-locals = 20
 
 [tool.tox]
 legacy_tox_ini = """

--- a/tests/concurrent_tests/periodic_packer.py
+++ b/tests/concurrent_tests/periodic_packer.py
@@ -3,6 +3,7 @@
 
 This is used to test concurrency while using the container and packing at the same time.
 """
+
 import datetime
 import time
 
@@ -13,28 +14,28 @@ from disk_objectstore import Container
 
 def timestamp():
     """Return a timestamp string to print for logging."""
-    return datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
+    return datetime.datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
 
 
 @click.command()
 @click.option(
-    "-p",
-    "--path",
-    default="/tmp/test-container",
-    help="The path to a test folder in which the container will be created.",
+    '-p',
+    '--path',
+    default='/tmp/test-container',
+    help='The path to a test folder in which the container will be created.',
 )
 @click.option(
-    "-r", "--repetitions", default=10, help="Number of repetitions before stopping."
+    '-r', '--repetitions', default=10, help='Number of repetitions before stopping.'
 )
 @click.option(
-    "-w", "--wait-time", default=0.83, help="Time to wait between iterations."
+    '-w', '--wait-time', default=0.83, help='Time to wait between iterations.'
 )
-@click.help_option("-h", "--help")
+@click.help_option('-h', '--help')
 def main(path, repetitions, wait_time):
     """Periodically pack container."""
     container = Container(path)
     if not container.is_initialised:
-        raise ValueError("Can only pack initialised containers.")
+        raise ValueError('Can only pack initialised containers.')
 
     for iteration in range(repetitions):
         if iteration != 0:
@@ -43,7 +44,7 @@ def main(path, repetitions, wait_time):
         compress_packs = iteration % 2 == 0
         start_counts = container.count_objects()
         container.pack_all_loose(compress=compress_packs)
-        print(f"[PACKER {timestamp()}] Done packing!")
+        print(f'[PACKER {timestamp()}] Done packing!')
         end_counts = container.count_objects()
 
         print(
@@ -53,5 +54,5 @@ def main(path, repetitions, wait_time):
         )
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()  # pylint: disable=no-value-for-parameter

--- a/tests/concurrent_tests/periodic_packer.py
+++ b/tests/concurrent_tests/periodic_packer.py
@@ -24,12 +24,8 @@ def timestamp():
     default='/tmp/test-container',
     help='The path to a test folder in which the container will be created.',
 )
-@click.option(
-    '-r', '--repetitions', default=10, help='Number of repetitions before stopping.'
-)
-@click.option(
-    '-w', '--wait-time', default=0.83, help='Time to wait between iterations.'
-)
+@click.option('-r', '--repetitions', default=10, help='Number of repetitions before stopping.')
+@click.option('-w', '--wait-time', default=0.83, help='Time to wait between iterations.')
 @click.help_option('-h', '--help')
 def main(path, repetitions, wait_time):
     """Periodically pack container."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Configuration file for pytest tests."""
+
 import hashlib
 import os
 import random
@@ -14,10 +15,10 @@ from disk_objectstore import Container
 def pytest_addoption(parser):
     """Parse a new option for the number of repetitions for the concurrency tests."""
     parser.addoption(
-        "--concurrency-repetitions",
+        '--concurrency-repetitions',
         type=int,
         default=1,
-        help="Specify how many time to repeat the concurrency tests",
+        help='Specify how many time to repeat the concurrency tests',
     )
 
 
@@ -26,14 +27,14 @@ def pytest_generate_tests(metafunc):
 
     The number of repetitions can be specified on the command line with ``--concurrency-repetitions=3``.
     """
-    if "concurrency_repetition_index" in metafunc.fixturenames:
+    if 'concurrency_repetition_index' in metafunc.fixturenames:
         metafunc.parametrize(
-            "concurrency_repetition_index",
+            'concurrency_repetition_index',
             range(metafunc.config.option.concurrency_repetitions),
         )
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope='function')
 def callback_instance():
     """Return the CallbackClass for the tests."""
 
@@ -48,15 +49,15 @@ def callback_instance():
         def callback(self, action, value):
             """Check how the callback is called."""
 
-            if action == "init":
+            if action == 'init':
                 assert (
                     self.current_action is None
                 ), f"Starting a new action '{action}' without closing the old one {self.current_action}"
-                self.current_action = {"start_value": value, "value": 0}
-            elif action == "update":
+                self.current_action = {'start_value': value, 'value': 0}
+            elif action == 'update':
                 # Track the current position
-                self.current_action["value"] += value
-            elif action == "close":
+                self.current_action['value'] += value
+            elif action == 'close':
                 # Add to list of performed actions
                 self.performed_actions.append(self.current_action)
                 self.current_action = None
@@ -66,7 +67,7 @@ def callback_instance():
     yield CallbackClass()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope='function')
 def temp_container(temp_dir):  # pylint: disable=redefined-outer-name
     """Return an object-store container in a given temporary directory.
 
@@ -80,7 +81,7 @@ def temp_container(temp_dir):  # pylint: disable=redefined-outer-name
     container.close()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope='function')
 def temp_dir():
     """Get a temporary directory.
 
@@ -95,7 +96,7 @@ def temp_dir():
         shutil.rmtree(dirpath)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope='function')
 def generate_random_data():
     """Return a function to generate a number of random byte strings.
 
@@ -132,7 +133,7 @@ def generate_random_data():
     yield _generate_random_data
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope='function')
 def lock_file_on_windows():
     """
     Return a function that, given a file desciptor (as returned by ``os.open``, locks it (on Windows)
@@ -148,7 +149,7 @@ def lock_file_on_windows():
 
         :param file_descriptor: a file descriptor, opened with `os.open()`
         """
-        assert os.name == "nt", "This fixture can only be used on Windows"
+        assert os.name == 'nt', 'This fixture can only be used on Windows'
 
         # This should run on Windows, but the linter runs on Ubuntu where these modules
         # do not exist. Therefore, ignore errors in this function.

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,6 +1,4 @@
-"""Test the backup functionality.
-
-"""
+"""Test the backup functionality."""
 
 import logging
 import platform
@@ -15,63 +13,63 @@ from disk_objectstore import backup_utils
 from disk_objectstore.backup_utils import BackupError, BackupManager
 
 pytestmark = pytest.mark.skipif(
-    platform.system() == "Windows", reason="Backup not supported on Windows"
+    platform.system() == 'Windows', reason='Backup not supported on Windows'
 )
 
 
 def _random_string(n=10):
-    return "".join(random.choices(string.ascii_lowercase + string.digits, k=n))
+    return ''.join(random.choices(string.ascii_lowercase + string.digits, k=n))
 
 
 def test_invalid_destination():
     """Test invalid destination with two colons."""
-    dest = "localhost:/tmp/test:"
-    with pytest.raises(ValueError, match="Invalid destination format"):
+    dest = 'localhost:/tmp/test:'
+    with pytest.raises(ValueError, match='Invalid destination format'):
         BackupManager(dest)
 
 
 def test_inaccessible_remote():
     """Test a remote destination of random characters that will not be accessible."""
-    dest = f"_{_random_string()}:/tmp/test"
-    with pytest.raises(BackupError, match="is not accessible"):
+    dest = f'_{_random_string()}:/tmp/test'
+    with pytest.raises(BackupError, match='is not accessible'):
         BackupManager(dest)
 
 
 def test_negative_keep():
     """Test a negative keep value."""
-    dest = "/tmp/test"
+    dest = '/tmp/test'
     with pytest.raises(ValueError, match="keep variable can't be negative"):
         BackupManager(dest, keep=-1)
 
 
 def test_inaccessible_exe():
     """Test case where rsync is not accessible."""
-    dest = "/tmp/test"
-    rsync_exe = f"_{_random_string()}"
-    with pytest.raises(ValueError, match=f"{rsync_exe} not accessible."):
+    dest = '/tmp/test'
+    rsync_exe = f'_{_random_string()}'
+    with pytest.raises(ValueError, match=f'{rsync_exe} not accessible.'):
         BackupManager(dest, rsync_exe=rsync_exe)
 
 
 def test_inaccessible_path():
     """Test case where path is not accessible."""
-    dest = f"/_{_random_string()}"  # I assume there will be a permission error for this path
+    dest = f'/_{_random_string()}'  # I assume there will be a permission error for this path
     with pytest.raises(ValueError, match=f"Couldn't access/create '{dest}'"):
         BackupManager(dest)
 
 
 def test_rsync_failure():
     """Test case where rsync fails."""
-    dest = "/tmp/test"
-    with pytest.raises(BackupError, match="rsync failed"):
+    dest = '/tmp/test'
+    with pytest.raises(BackupError, match='rsync failed'):
         manager = BackupManager(dest)
         # pick a src that doesn't exists
-        manager.call_rsync(Path(f"/_{_random_string()}"), Path(dest))
+        manager.call_rsync(Path(f'/_{_random_string()}'), Path(dest))
 
 
 def test_rsync_dest_trailing_slash(tmp_path):
     """Test case for dest_trailing_slash."""
-    dest1 = tmp_path / "dest1"
-    dest2 = tmp_path / "dest2"
+    dest1 = tmp_path / 'dest1'
+    dest2 = tmp_path / 'dest2'
     # manager will create dest1 folder
     manager = BackupManager(str(dest1))
     # dest_trailing_slash=True will create dest2
@@ -86,7 +84,7 @@ def test_rsync_legacy_progress(monkeypatch, tmp_path, capfd):
     and it's progress instead of a global progress like '--info=progress2'.
     """
 
-    logging.getLogger("disk_objectstore").setLevel(logging.INFO)
+    logging.getLogger('disk_objectstore').setLevel(logging.INFO)
 
     # monkeypatch the get_rsync_major_version
     def mock_get_rsync_major_version(_self):
@@ -94,19 +92,19 @@ def test_rsync_legacy_progress(monkeypatch, tmp_path, capfd):
 
     monkeypatch.setattr(
         backup_utils.BackupManager,
-        "get_rsync_major_version",
+        'get_rsync_major_version',
         mock_get_rsync_major_version,
     )
 
-    dest1 = tmp_path / "dest1"
-    dest2 = tmp_path / "dest2"
+    dest1 = tmp_path / 'dest1'
+    dest2 = tmp_path / 'dest2'
 
     dest1.mkdir(parents=True)
 
-    fname = "test_file.txt"
+    fname = 'test_file.txt'
     file_path = dest1 / fname
-    with open(file_path, "w") as f:
-        f.write("Test content\n")
+    with open(file_path, 'w') as f:
+        f.write('Test content\n')
 
     manager = BackupManager(str(dest2))
     manager.call_rsync(dest1, dest2, src_trailing_slash=True)
@@ -121,20 +119,20 @@ def test_get_rsync_major_version_failure(monkeypatch):
     """Test case where rsync version fails."""
 
     def mock_subprocess_run(*args, **_kwargs):
-        return subprocess.CompletedProcess(args, 0, "unexpected", "")
+        return subprocess.CompletedProcess(args, 0, 'unexpected', '')
 
-    monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
-    manager = BackupManager("/tmp")
+    monkeypatch.setattr(subprocess, 'run', mock_subprocess_run)
+    manager = BackupManager('/tmp')
     assert manager.get_rsync_major_version() is None
 
 
 def test_existing_backups_failure():
     """Test case where existing backups fail to be determined."""
-    dest = "/tmp/test"
-    with pytest.raises(BackupError, match="Existing backups determination failed"):
+    dest = '/tmp/test'
+    with pytest.raises(BackupError, match='Existing backups determination failed'):
         manager = BackupManager(dest)
         # override the path to something that will fail
-        manager.path = f"/_{_random_string()}"
+        manager.path = f'/_{_random_string()}'
         manager.get_existing_backup_folders()
 
 
@@ -147,7 +145,7 @@ def test_sqlite_failure(monkeypatch, temp_container, tmp_path):
 
     monkeypatch.setattr(
         backup_utils,
-        "_sqlite_backup",
+        '_sqlite_backup',
         mock_sqlite_backup,
     )
 
@@ -155,9 +153,9 @@ def test_sqlite_failure(monkeypatch, temp_container, tmp_path):
     temp_container.init_container(clear=True)
     # Add a few objects
     for idx in range(100):
-        temp_container.add_object(f"test-{idx}".encode())
+        temp_container.add_object(f'test-{idx}'.encode())
 
-    dest = tmp_path / "backup"
+    dest = tmp_path / 'backup'
     with pytest.raises(BackupError, match="'.*' failed to be created."):
         manager = BackupManager(str(dest))
         manager.backup_auto_folders(
@@ -178,13 +176,13 @@ def test_mv_failure(monkeypatch, temp_container, tmp_path):
 
     # monkeypatch the run_cmd command to fail when "mv" is used
     def mock_run_cmd(self, args):
-        if "mv" in args:
-            return False, ""
+        if 'mv' in args:
+            return False, ''
         return original_run_cmd(self, args)
 
     monkeypatch.setattr(
         backup_utils.BackupManager,
-        "run_cmd",
+        'run_cmd',
         mock_run_cmd,
     )
 
@@ -192,10 +190,10 @@ def test_mv_failure(monkeypatch, temp_container, tmp_path):
     temp_container.init_container(clear=True)
     # Add a few objects
     for idx in range(100):
-        temp_container.add_object(f"test-{idx}".encode())
+        temp_container.add_object(f'test-{idx}'.encode())
 
-    dest = tmp_path / "backup"
-    with pytest.raises(BackupError, match="Failed to move"):
+    dest = tmp_path / 'backup'
+    with pytest.raises(BackupError, match='Failed to move'):
         manager = BackupManager(str(dest))
         manager.backup_auto_folders(
             lambda path, prev: backup_utils.backup_container(
@@ -215,13 +213,13 @@ def test_ln_failure(monkeypatch, temp_container, tmp_path, caplog):
 
     # monkeypatch the run_cmd command to fail when "mv" is used
     def mock_run_cmd(self, args):
-        if "ln" in args:
-            return False, ""
+        if 'ln' in args:
+            return False, ''
         return original_run_cmd(self, args)
 
     monkeypatch.setattr(
         backup_utils.BackupManager,
-        "run_cmd",
+        'run_cmd',
         mock_run_cmd,
     )
 
@@ -229,9 +227,9 @@ def test_ln_failure(monkeypatch, temp_container, tmp_path, caplog):
     temp_container.init_container(clear=True)
     # Add a few objects
     for idx in range(100):
-        temp_container.add_object(f"test-{idx}".encode())
+        temp_container.add_object(f'test-{idx}'.encode())
 
-    dest = tmp_path / "backup"
+    dest = tmp_path / 'backup'
     manager = BackupManager(str(dest))
     manager.backup_auto_folders(
         lambda path, prev: backup_utils.backup_container(
@@ -253,13 +251,13 @@ def test_rm_failure(monkeypatch, temp_container, tmp_path, caplog):
 
     # monkeypatch the run_cmd command to fail when "mv" is used
     def mock_run_cmd(self, args):
-        if "rm" in args:
-            return False, ""
+        if 'rm' in args:
+            return False, ''
         return original_run_cmd(self, args)
 
     monkeypatch.setattr(
         backup_utils.BackupManager,
-        "run_cmd",
+        'run_cmd',
         mock_run_cmd,
     )
 
@@ -267,9 +265,9 @@ def test_rm_failure(monkeypatch, temp_container, tmp_path, caplog):
     temp_container.init_container(clear=True)
     # Add a few objects
     for idx in range(100):
-        temp_container.add_object(f"test-{idx}".encode())
+        temp_container.add_object(f'test-{idx}'.encode())
 
-    dest = tmp_path / "backup"
+    dest = tmp_path / 'backup'
     manager = BackupManager(str(dest), keep=0)
     for _ in range(2):
         manager.backup_auto_folders(

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -12,9 +12,7 @@ import pytest
 from disk_objectstore import backup_utils
 from disk_objectstore.backup_utils import BackupError, BackupManager
 
-pytestmark = pytest.mark.skipif(
-    platform.system() == 'Windows', reason='Backup not supported on Windows'
-)
+pytestmark = pytest.mark.skipif(platform.system() == 'Windows', reason='Backup not supported on Windows')
 
 
 def _random_string(n=10):
@@ -159,9 +157,7 @@ def test_sqlite_failure(monkeypatch, temp_container, tmp_path):
     with pytest.raises(BackupError, match="'.*' failed to be created."):
         manager = BackupManager(str(dest))
         manager.backup_auto_folders(
-            lambda path, prev: backup_utils.backup_container(
-                manager, temp_container, path, prev
-            )
+            lambda path, prev: backup_utils.backup_container(manager, temp_container, path, prev)
         )
 
 
@@ -196,9 +192,7 @@ def test_mv_failure(monkeypatch, temp_container, tmp_path):
     with pytest.raises(BackupError, match='Failed to move'):
         manager = BackupManager(str(dest))
         manager.backup_auto_folders(
-            lambda path, prev: backup_utils.backup_container(
-                manager, temp_container, path, prev
-            )
+            lambda path, prev: backup_utils.backup_container(manager, temp_container, path, prev)
         )
 
 
@@ -231,11 +225,7 @@ def test_ln_failure(monkeypatch, temp_container, tmp_path, caplog):
 
     dest = tmp_path / 'backup'
     manager = BackupManager(str(dest))
-    manager.backup_auto_folders(
-        lambda path, prev: backup_utils.backup_container(
-            manager, temp_container, path, prev
-        )
-    )
+    manager.backup_auto_folders(lambda path, prev: backup_utils.backup_container(manager, temp_container, path, prev))
     assert "Couldn't create symlink" in caplog.text
 
 
@@ -271,8 +261,6 @@ def test_rm_failure(monkeypatch, temp_container, tmp_path, caplog):
     manager = BackupManager(str(dest), keep=0)
     for _ in range(2):
         manager.backup_auto_folders(
-            lambda path, prev: backup_utils.backup_container(
-                manager, temp_container, path, prev
-            )
+            lambda path, prev: backup_utils.backup_container(manager, temp_container, path, prev)
         )
     assert "Warning: couldn't delete old backup" in caplog.text

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -38,9 +38,7 @@ def test_concurrent_append_read(temp_dir):
             write_handle.flush()
 
             # Check that the file size on disk is the expected one
-            assert fpath.stat().st_size == len(first_part) + len(intermediate) + len(
-                second_part
-            )
+            assert fpath.stat().st_size == len(first_part) + len(intermediate) + len(second_part)
 
             # Now, jump to the beginning of the second part for reading (skipping 'intermediate')
             read_handle.seek(len(first_part) + len(intermediate))
@@ -86,9 +84,7 @@ def test_concurrent_append_read_multiprocess(temp_dir):
             ]
         )
 
-        assert filesize_str == str(
-            len(first_part) + len(intermediate) + len(second_part)
-        ).encode('ascii')
+        assert filesize_str == str(len(first_part) + len(intermediate) + len(second_part)).encode('ascii')
 
         # Now, jump to the beginning of the second part for reading (skipping 'intermediate')
         read_chunk = subprocess.check_output(
@@ -212,16 +208,10 @@ def test_deletion_while_open(temp_dir, bytes_read_pre):
             # - os.streerror(exc.errno) == 'Permission denied'
             output = exc.output or b''  # It could be none
             assert b'PermissionError' in output
-            assert (
-                fpath.is_file()
-            ), 'The file was actually deleted on Windows, unexpected!'
+            assert fpath.is_file(), 'The file was actually deleted on Windows, unexpected!'
         else:
-            assert (
-                os.name == 'posix'
-            ), "I should be able to delete a file while it's still open only on POSIX!"
-            assert (
-                not fpath.is_file()
-            ), "The file wasn't really deleted in POSIX, unexpected!"
+            assert os.name == 'posix', "I should be able to delete a file while it's still open only on POSIX!"
+            assert not fpath.is_file(), "The file wasn't really deleted in POSIX, unexpected!"
 
         # In either case (I got an exception on Windows, I could delete the file on POSIX)
         # I should still be able to read the correct content.
@@ -281,9 +271,7 @@ def test_rename_when_existing(temp_dir):
             assert fpath_replacement.exists()
             # I continue
         else:
-            assert (
-                os.name == 'posix'
-            ), 'I should be able to rername a file to an open destination on POSIX!'
+            assert os.name == 'posix', 'I should be able to rername a file to an open destination on POSIX!'
 
             # The source should still not be there anymore
             assert not fpath_replacement.exists()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -2,6 +2,7 @@
 
 This is also a way to verify the behavior of the underlying OS/filesystem.
 """
+
 import os
 import subprocess
 import sys
@@ -13,20 +14,20 @@ import pytest
 
 def test_concurrent_append_read(temp_dir):
     """Check what happens when reading a file that is being written in append mode in the meantime."""
-    fpath = temp_dir / "test_file"
+    fpath = temp_dir / 'test_file'
 
-    first_part = b"v92jgwkf"
-    intermediate = b"fbd9pjv2klmwg"
-    second_part = b"2flemawlefm"
+    first_part = b'v92jgwkf'
+    intermediate = b'fbd9pjv2klmwg'
+    second_part = b'2flemawlefm'
 
-    with open(fpath, "ab") as write_handle:
+    with open(fpath, 'ab') as write_handle:
         write_handle.write(first_part)
         # Flush to make sure everything is out of the buffer and visible to other processes
         write_handle.flush()
 
         # Verify that I can open in read mode and that I already find the content,
         # even if the write_handle is not closed
-        with open(fpath, "rb") as read_handle:
+        with open(fpath, 'rb') as read_handle:
             # Read the first part, check it's correct
             read_chunk = read_handle.read(len(first_part))
             assert read_chunk == first_part
@@ -49,13 +50,13 @@ def test_concurrent_append_read(temp_dir):
 
 def test_concurrent_append_read_multiprocess(temp_dir):
     """Check what happens when reading a file that is being written in append mode in the meantime."""
-    fpath = temp_dir / "test_file"
+    fpath = temp_dir / 'test_file'
 
-    first_part = b"v92jgwkf"
-    intermediate = b"fbd9pjv2klmwg"
-    second_part = b"2flemawlefm"
+    first_part = b'v92jgwkf'
+    intermediate = b'fbd9pjv2klmwg'
+    second_part = b'2flemawlefm'
 
-    with open(fpath, "ab") as write_handle:
+    with open(fpath, 'ab') as write_handle:
         write_handle.write(first_part)
         # Flush to make sure everything is out of the buffer and visible to other processes
         write_handle.flush()
@@ -65,7 +66,7 @@ def test_concurrent_append_read_multiprocess(temp_dir):
         read_chunk = subprocess.check_output(
             [
                 sys.executable,
-                "-c",
+                '-c',
                 f'fhandle=open(r"{fpath.resolve()}"); print(fhandle.read(), end=""); fhandle.close()',
             ]
         )
@@ -80,22 +81,22 @@ def test_concurrent_append_read_multiprocess(temp_dir):
         filesize_str = subprocess.check_output(
             [
                 sys.executable,
-                "-c",
-                f'import pathlib; print(pathlib.Path(r"{str(fpath)}").resolve().stat().st_size, end="")',
+                '-c',
+                f'import pathlib; print(pathlib.Path(r"{fpath!s}").resolve().stat().st_size, end="")',
             ]
         )
 
         assert filesize_str == str(
             len(first_part) + len(intermediate) + len(second_part)
-        ).encode("ascii")
+        ).encode('ascii')
 
         # Now, jump to the beginning of the second part for reading (skipping 'intermediate')
         read_chunk = subprocess.check_output(
             [
                 sys.executable,
-                "-c",
+                '-c',
                 f'fhandle=open(r"{fpath.resolve()}"); '
-                f"fhandle.seek({len(first_part) + len(intermediate)}); "
+                f'fhandle.seek({len(first_part) + len(intermediate)}); '
                 'print(fhandle.read(), end=""); fhandle.close()',
             ]
         )
@@ -113,17 +114,17 @@ def test_concurrent_append_write_buffer_size(temp_dir):
 
     If the file is read as a buffer, I would expect that it might not notice immediately that content has been appended.
     """
-    fpath = temp_dir / "test_file"
+    fpath = temp_dir / 'test_file'
 
-    first_part = b"v92"
-    intermediate = b"efwefdf"
-    second_part = b"2flemawlefm"
+    first_part = b'v92'
+    intermediate = b'efwefdf'
+    second_part = b'2flemawlefm'
 
     # Let's write 2 bytes in the file
-    with open(fpath, "wb") as write_handle:
+    with open(fpath, 'wb') as write_handle:
         write_handle.write(first_part)
 
-    with open(fpath, "rb") as read_handle:
+    with open(fpath, 'rb') as read_handle:
         # Read only 1 byte
         beginning = read_handle.read(1)
         assert beginning == first_part[:1]
@@ -132,7 +133,7 @@ def test_concurrent_append_write_buffer_size(temp_dir):
         subprocess.check_output(
             [
                 sys.executable,
-                "-c",
+                '-c',
                 f'fhandle=open(r"{fpath.resolve()}", "ab"); '
                 f'fhandle.write(b"{intermediate.decode("ascii")}"); fhandle.close()',
             ]
@@ -150,7 +151,7 @@ def test_concurrent_append_write_buffer_size(temp_dir):
         subprocess.check_output(
             [
                 sys.executable,
-                "-c",
+                '-c',
                 f'fhandle=open(r"{fpath.resolve()}", "ab"); '
                 f'fhandle.write(b"{second_part.decode("ascii")}"); fhandle.close()',
             ]
@@ -164,7 +165,7 @@ def test_concurrent_append_write_buffer_size(temp_dir):
         assert end == second_part
 
 
-@pytest.mark.parametrize("bytes_read_pre", [0, 3])
+@pytest.mark.parametrize('bytes_read_pre', [0, 3])
 def test_deletion_while_open(temp_dir, bytes_read_pre):
     """Check the different behavior of deletion of an open file (in read mode).
 
@@ -173,21 +174,21 @@ def test_deletion_while_open(temp_dir, bytes_read_pre):
 
     :param bytes_read_pre: an integer stating how many bytes to read before (trying to) delete the open file.
     """
-    fpath = temp_dir / "test_file"
+    fpath = temp_dir / 'test_file'
 
-    content = b"rfr23ewv3wg4w"
+    content = b'rfr23ewv3wg4w'
     assert len(content) >= bytes_read_pre
 
     # Write something to the file
-    with open(fpath, "wb") as fhandle:
+    with open(fpath, 'wb') as fhandle:
         fhandle.write(content)
 
     # Now open again the file
-    with open(fpath, "rb") as fhandle:
+    with open(fpath, 'rb') as fhandle:
         if bytes_read_pre:
             read_content_pre = fhandle.read(bytes_read_pre)
         else:
-            read_content_pre = b""
+            read_content_pre = b''
 
         # I (try to) delete the file in a different subprocess
         try:
@@ -195,7 +196,7 @@ def test_deletion_while_open(temp_dir, bytes_read_pre):
             subprocess.check_output(
                 [
                     sys.executable,
-                    "-c",
+                    '-c',
                     f'import os; os.remove(r"{fpath.resolve()}")',
                 ],
                 stderr=subprocess.STDOUT,
@@ -204,19 +205,19 @@ def test_deletion_while_open(temp_dir, bytes_read_pre):
             # On Windows, I should get:
             # PermissionError: [WinError 32] The process cannot access the file because
             # it is begin used by another process: '<filename>'
-            assert os.name == "nt", "I should get a PermissionError only on Windows!"
+            assert os.name == 'nt', 'I should get a PermissionError only on Windows!'
 
             # I cannot check the error code since it's a different subprocess. As a note, it should be:
             # - errno.EACCES == 13
             # - os.streerror(exc.errno) == 'Permission denied'
-            output = exc.output or b""  # It could be none
-            assert b"PermissionError" in output
+            output = exc.output or b''  # It could be none
+            assert b'PermissionError' in output
             assert (
                 fpath.is_file()
-            ), "The file was actually deleted on Windows, unexpected!"
+            ), 'The file was actually deleted on Windows, unexpected!'
         else:
             assert (
-                os.name == "posix"
+                os.name == 'posix'
             ), "I should be able to delete a file while it's still open only on POSIX!"
             assert (
                 not fpath.is_file()
@@ -235,7 +236,7 @@ def test_deletion_while_open(temp_dir, bytes_read_pre):
 
     # Now the file is closed. On POSIX, I know it's not there.
     # Let me try to delete it also on Windows.
-    if os.name == "nt":
+    if os.name == 'nt':
         # Now that the file is closed, I should be able to remove it
         os.remove(fpath)
 
@@ -249,24 +250,24 @@ def test_rename_when_existing(temp_dir):
     On POSIX: I can delete silently rename even if open.
     On Windows: I cannot rename a file to a location where a file already exists.
     """
-    fpath = temp_dir / "test_file"
-    fpath_replacement = temp_dir / "test_file_repl"
+    fpath = temp_dir / 'test_file'
+    fpath_replacement = temp_dir / 'test_file_repl'
 
-    content = b"rfr23ewv3wg4w"
+    content = b'rfr23ewv3wg4w'
     first_part_len = 4
 
-    new_content = b"NEWFILECONTENT"
+    new_content = b'NEWFILECONTENT'
 
     # Write something to the file
-    with open(fpath, "wb") as fhandle:
+    with open(fpath, 'wb') as fhandle:
         fhandle.write(content)
 
     # Write something to the file
-    with open(fpath_replacement, "wb") as fhandle:
+    with open(fpath_replacement, 'wb') as fhandle:
         fhandle.write(new_content)
 
     # Now open again the file
-    with open(fpath, "rb") as fhandle:
+    with open(fpath, 'rb') as fhandle:
         read_content_pre = fhandle.read(first_part_len)
 
         # I (try to) rename the file where the dest is the file that is open
@@ -274,15 +275,15 @@ def test_rename_when_existing(temp_dir):
             os.rename(fpath_replacement, fpath)
         except FileExistsError:
             # This should happen only on Windows
-            assert os.name == "nt", "I should get a FileExistsError only on Windows!"
+            assert os.name == 'nt', 'I should get a FileExistsError only on Windows!'
 
             # The source should still be there
             assert fpath_replacement.exists()
             # I continue
         else:
             assert (
-                os.name == "posix"
-            ), "I should be able to rername a file to an open destination on POSIX!"
+                os.name == 'posix'
+            ), 'I should be able to rername a file to an open destination on POSIX!'
 
             # The source should still not be there anymore
             assert not fpath_replacement.exists()
@@ -294,9 +295,9 @@ def test_rename_when_existing(temp_dir):
         assert read_content == content
 
     # I reopen the file
-    with open(fpath, "rb") as fhandle:
+    with open(fpath, 'rb') as fhandle:
         read_content = fhandle.read()
-        if os.name == "nt":
+        if os.name == 'nt':
             # On Windows I should still get the old content
             assert read_content == content
         else:
@@ -305,7 +306,7 @@ def test_rename_when_existing(temp_dir):
 
     # I remove and replace the file on Windows to check that
     # I can indeed replace it
-    if os.name == "nt":
+    if os.name == 'nt':
         os.remove(fpath)
         os.rename(fpath_replacement, fpath)
 
@@ -313,23 +314,23 @@ def test_rename_when_existing(temp_dir):
     assert not fpath_replacement.exists()
 
     # Now I should have the new file on any platform
-    with open(fpath, "rb") as fhandle:
+    with open(fpath, 'rb') as fhandle:
         read_content = fhandle.read()
         assert read_content == new_content
 
 
 # Run only on Windows where we want to check the locking behavior
-@pytest.mark.skipif(os.name != "nt", reason="This test only makes sense on Windows")
+@pytest.mark.skipif(os.name != 'nt', reason='This test only makes sense on Windows')
 def test_exclusive_mode_windows(temp_dir, lock_file_on_windows):
     """Test that indeed I can open a file with exclusive lock on Windows.
 
     This means someone else cannot even open the file in read mode.
     """
-    fpath = temp_dir / "test_file"
-    content = b"sfsfdkl;2fd"
+    fpath = temp_dir / 'test_file'
+    content = b'sfsfdkl;2fd'
 
     # Write something to the file
-    with open(fpath, "wb") as fhandle:
+    with open(fpath, 'wb') as fhandle:
         fhandle.write(content)
 
     # Now open the file with exclusive locking
@@ -343,20 +344,20 @@ def test_exclusive_mode_windows(temp_dir, lock_file_on_windows):
         output = subprocess.check_output(
             [
                 sys.executable,
-                "-c",
+                '-c',
                 f'f=open(r"{fpath.resolve()}", "rb"); print(f.read()); f.close()',
             ],
             stderr=subprocess.STDOUT,
         )
     except subprocess.CalledProcessError as exc:
         # I should get a PermissionError
-        output = exc.output or b""  # It could be none
-        assert b"PermissionError" in output
-        read_content = os.fdopen(fd, "rb", closefd=False).read()
-        assert read_content == content, f"Unexpeced content: {read_content}"
+        output = exc.output or b''  # It could be none
+        assert b'PermissionError' in output
+        read_content = os.fdopen(fd, 'rb', closefd=False).read()
+        assert read_content == content, f'Unexpeced content: {read_content}'
         del read_content
     else:
-        raise AssertionError(f"Subprocess should have raised! OUTPUT:\n{output}")
+        raise AssertionError(f'Subprocess should have raised! OUTPUT:\n{output}')
     finally:
         # Close the file at the end, important!
         # If I close, I shouldn't need to unlock

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -11,13 +11,9 @@ def test_pack_write(temp_container, benchmark):
     """Add 10'000 objects to the container in packed form, and benchmark write and read speed."""
     num_files = 10000
     data_content = [str(i).encode('ascii') for i in range(num_files)]
-    expected_hashkeys = [
-        hashlib.sha256(content).hexdigest() for content in data_content
-    ]
+    expected_hashkeys = [hashlib.sha256(content).hexdigest() for content in data_content]
 
-    hashkeys = benchmark(
-        temp_container.add_objects_to_pack, data_content, compress=False
-    )
+    hashkeys = benchmark(temp_container.add_objects_to_pack, data_content, compress=False)
 
     assert len(hashkeys) == len(data_content)
     assert expected_hashkeys == hashkeys
@@ -28,9 +24,7 @@ def test_loose_write(temp_container, benchmark):
     """Add 1'000 objects to the container in packed form, and benchmark write and read speed."""
     num_files = 1000
     data_content = [str(i).encode('ascii') for i in range(num_files)]
-    expected_hashkeys = [
-        hashlib.sha256(content).hexdigest() for content in data_content
-    ]
+    expected_hashkeys = [hashlib.sha256(content).hexdigest() for content in data_content]
 
     def write_loose(container, contents):
         retval = []
@@ -49,9 +43,7 @@ def test_pack_read(temp_container, benchmark):
     """Add 10'000 objects to the container in packed form, and benchmark write and read speed."""
     num_files = 10000
     data_content = [str(i).encode('ascii') for i in range(num_files)]
-    expected_hashkeys = [
-        hashlib.sha256(content).hexdigest() for content in data_content
-    ]
+    expected_hashkeys = [hashlib.sha256(content).hexdigest() for content in data_content]
     expected_results_dict = dict(zip(expected_hashkeys, data_content))
 
     hashkeys = temp_container.add_objects_to_pack(data_content, compress=False)
@@ -89,14 +81,10 @@ def test_has_objects(temp_container, benchmark):
     num_files_half = 5000
     data_content_packed = [str(i).encode('ascii') for i in range(num_files_half)]
 
-    hashkeys_packed = temp_container.add_objects_to_pack(
-        data_content_packed, compress=False
-    )
+    hashkeys_packed = temp_container.add_objects_to_pack(data_content_packed, compress=False)
 
     # Different set of data for the loose objects, not colliding
-    data_content_loose = [
-        b'LOOSE' + str(i).encode('ascii') for i in range(num_files_half)
-    ]
+    data_content_loose = [b'LOOSE' + str(i).encode('ascii') for i in range(num_files_half)]
 
     hashkeys_loose = []
     for content in data_content_loose:

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,15 +1,16 @@
 """Test the performance of the container implementation."""
+
 import hashlib
 import random
 
 import pytest
 
 
-@pytest.mark.benchmark(group="write", min_rounds=3)
+@pytest.mark.benchmark(group='write', min_rounds=3)
 def test_pack_write(temp_container, benchmark):
     """Add 10'000 objects to the container in packed form, and benchmark write and read speed."""
     num_files = 10000
-    data_content = [str(i).encode("ascii") for i in range(num_files)]
+    data_content = [str(i).encode('ascii') for i in range(num_files)]
     expected_hashkeys = [
         hashlib.sha256(content).hexdigest() for content in data_content
     ]
@@ -22,11 +23,11 @@ def test_pack_write(temp_container, benchmark):
     assert expected_hashkeys == hashkeys
 
 
-@pytest.mark.benchmark(group="write", min_rounds=3)
+@pytest.mark.benchmark(group='write', min_rounds=3)
 def test_loose_write(temp_container, benchmark):
     """Add 1'000 objects to the container in packed form, and benchmark write and read speed."""
     num_files = 1000
-    data_content = [str(i).encode("ascii") for i in range(num_files)]
+    data_content = [str(i).encode('ascii') for i in range(num_files)]
     expected_hashkeys = [
         hashlib.sha256(content).hexdigest() for content in data_content
     ]
@@ -43,11 +44,11 @@ def test_loose_write(temp_container, benchmark):
     assert expected_hashkeys == hashkeys
 
 
-@pytest.mark.benchmark(group="read")
+@pytest.mark.benchmark(group='read')
 def test_pack_read(temp_container, benchmark):
     """Add 10'000 objects to the container in packed form, and benchmark write and read speed."""
     num_files = 10000
-    data_content = [str(i).encode("ascii") for i in range(num_files)]
+    data_content = [str(i).encode('ascii') for i in range(num_files)]
     expected_hashkeys = [
         hashlib.sha256(content).hexdigest() for content in data_content
     ]
@@ -61,11 +62,11 @@ def test_pack_read(temp_container, benchmark):
     assert results == expected_results_dict
 
 
-@pytest.mark.benchmark(group="read")
+@pytest.mark.benchmark(group='read')
 def test_loose_read(temp_container, benchmark):
     """Add 1'000 objects to the container in loose form, and benchmark write and read speed."""
     num_files = 1000
-    data_content = [str(i).encode("ascii") for i in range(num_files)]
+    data_content = [str(i).encode('ascii') for i in range(num_files)]
     hashkeys = []
     for content in data_content:
         hashkeys.append(temp_container.add_object(content))
@@ -78,7 +79,7 @@ def test_loose_read(temp_container, benchmark):
     assert results == expected_results
 
 
-@pytest.mark.benchmark(group="check", min_rounds=3)
+@pytest.mark.benchmark(group='check', min_rounds=3)
 def test_has_objects(temp_container, benchmark):
     """Benchmark speed to check object existence.
 
@@ -86,7 +87,7 @@ def test_has_objects(temp_container, benchmark):
     of these 10'000 and of 5'000 more that do not exist.
     """
     num_files_half = 5000
-    data_content_packed = [str(i).encode("ascii") for i in range(num_files_half)]
+    data_content_packed = [str(i).encode('ascii') for i in range(num_files_half)]
 
     hashkeys_packed = temp_container.add_objects_to_pack(
         data_content_packed, compress=False
@@ -94,7 +95,7 @@ def test_has_objects(temp_container, benchmark):
 
     # Different set of data for the loose objects, not colliding
     data_content_loose = [
-        b"LOOSE" + str(i).encode("ascii") for i in range(num_files_half)
+        b'LOOSE' + str(i).encode('ascii') for i in range(num_files_half)
     ]
 
     hashkeys_loose = []
@@ -108,7 +109,7 @@ def test_has_objects(temp_container, benchmark):
     for hashkey in hashkeys_loose:
         existence_array.append((hashkey, True))
     for idx in range(num_files_half):
-        existence_array.append((f"UNKNOWN{idx}", False))
+        existence_array.append((f'UNKNOWN{idx}', False))
 
     # Shuffle pairs
     random.shuffle(existence_array)
@@ -121,11 +122,11 @@ def test_has_objects(temp_container, benchmark):
     assert result == list(expected_result)
 
 
-@pytest.mark.benchmark(group="read")
+@pytest.mark.benchmark(group='read')
 def test_list_all_packed(temp_container, benchmark):
     """Add 100'000 objects to the container in packed form, and benchmark list speed."""
     num_files = 100000
-    data_content = [str(i).encode("ascii") for i in range(num_files)]
+    data_content = [str(i).encode('ascii') for i in range(num_files)]
 
     hashkeys = temp_container.add_objects_to_pack(data_content, compress=False)
 
@@ -135,11 +136,11 @@ def test_list_all_packed(temp_container, benchmark):
     assert set(results) == set(hashkeys)
 
 
-@pytest.mark.benchmark(group="read")
+@pytest.mark.benchmark(group='read')
 def test_list_all_loose(temp_container, benchmark):
     """Add 10'000 loose objects to the container in packed form, and benchmark list speed."""
     num_files = 10000
-    data_content = [str(i).encode("ascii") for i in range(num_files)]
+    data_content = [str(i).encode('ascii') for i in range(num_files)]
 
     hashkeys = []
     for content in data_content:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -193,9 +193,7 @@ def test_validate_no_progressbar(temp_container, verbose, monkeypatch):
     assert 'No errors found' in result.stdout
 
 
-@pytest.mark.skipif(
-    platform.system() == 'Windows', reason='Backup not supported on Windows'
-)
+@pytest.mark.skipif(platform.system() == 'Windows', reason='Backup not supported on Windows')
 @pytest.mark.parametrize(
     'remote, verbosity',
     [
@@ -234,9 +232,7 @@ def test_backup(temp_container, temp_dir, remote, verbosity):
     assert path.exists()
 
     path_contents = [entry.name for entry in path.iterdir()]
-    backup_dirs = [
-        entry for entry in path.iterdir() if entry.name.startswith('backup_')
-    ]
+    backup_dirs = [entry for entry in path.iterdir() if entry.name.startswith('backup_')]
 
     assert 'last-backup' in path_contents
     assert len(backup_dirs) == 1
@@ -255,9 +251,7 @@ def test_backup(temp_container, temp_dir, remote, verbosity):
     assert 'No errors found' in result.stdout
 
 
-@pytest.mark.skipif(
-    platform.system() == 'Windows', reason='Backup not supported on Windows'
-)
+@pytest.mark.skipif(platform.system() == 'Windows', reason='Backup not supported on Windows')
 @pytest.mark.parametrize('remote', [False, True])
 def test_backup_repeated(temp_container, temp_dir, remote):
     """Test the backup command repeated 3 times.
@@ -285,17 +279,13 @@ def test_backup_repeated(temp_container, temp_dir, remote):
 
     assert path.exists()
     path_contents = [entry.name for entry in path.iterdir()]
-    backup_dirs = [
-        entry for entry in path.iterdir() if entry.name.startswith('backup_')
-    ]
+    backup_dirs = [entry for entry in path.iterdir() if entry.name.startswith('backup_')]
 
     assert 'last-backup' in path_contents
     assert len(backup_dirs) == 2
 
 
-@pytest.mark.skipif(
-    platform.system() == 'Windows', reason='Backup not supported on Windows'
-)
+@pytest.mark.skipif(platform.system() == 'Windows', reason='Backup not supported on Windows')
 def test_backup_failure(temp_container):
     """Test failure when providing invalid destination"""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 """Test the CLI commands"""
+
 import platform
 from pathlib import Path
 
@@ -11,10 +12,10 @@ from disk_objectstore.dataclasses import ObjectCount
 
 def test_main_command_missing_command(temp_dir):
     """Test calling the main command."""
-    result = CliRunner().invoke(cli.main, [f"--path={temp_dir}"])
+    result = CliRunner().invoke(cli.main, [f'--path={temp_dir}'])
     # This should fail
     assert result.exit_code != 0
-    assert "Missing command" in result.stdout
+    assert 'Missing command' in result.stdout
 
 
 def test_main_command_no_params():
@@ -22,13 +23,13 @@ def test_main_command_no_params():
     result = CliRunner().invoke(cli.main)
     # This should work and show a help/usage
     assert result.exit_code == 0
-    assert "Usage:" in result.stdout
-    assert "Commands:" in result.stdout
+    assert 'Usage:' in result.stdout
+    assert 'Commands:' in result.stdout
 
 
 def test_create(temp_dir):
     """Test creating a container"""
-    path = Path(temp_dir) / "dostore"
+    path = Path(temp_dir) / 'dostore'
     obj = cli.ContainerContext(path)
     result = CliRunner().invoke(cli.create, obj=obj)
     assert result.exit_code == 0, result.output
@@ -42,15 +43,15 @@ def test_create_with_explicit_pat(temp_dir):
     on the command line (passing as a ContainerContext will bypass some
     code in the `main` method in the `cli` module).
     """
-    path = Path(temp_dir) / "dostore"
-    result = CliRunner().invoke(cli.main, [f"--path={path}", "create"])
+    path = Path(temp_dir) / 'dostore'
+    result = CliRunner().invoke(cli.main, [f'--path={path}', 'create'])
     assert result.exit_code == 0, result.output
     assert path.exists()
 
 
 def test_create_exists(temp_dir):
     """Test creating a container that already exists fails"""
-    path = Path(temp_dir) / "dostore"
+    path = Path(temp_dir) / 'dostore'
     path.touch()
     obj = cli.ContainerContext(path)
     result = CliRunner().invoke(cli.create, obj=obj)
@@ -62,21 +63,21 @@ def test_status(temp_container):
     obj = cli.ContainerContext(temp_container.get_folder())
     result = CliRunner().invoke(cli.status, obj=obj)
     assert result.exit_code == 0, result.output
-    assert "path" in result.output
+    assert 'path' in result.output
 
 
 def test_status_not_exist():
     """Test status command when container does not exist"""
-    obj = cli.ContainerContext(Path("/does/not/exist"))
+    obj = cli.ContainerContext(Path('/does/not/exist'))
     result = CliRunner().invoke(cli.status, obj=obj)
     assert result.exit_code != 0, result.output
-    assert "Container does not exist" in result.output
+    assert 'Container does not exist' in result.output
 
 
 def test_add_file(temp_dir, temp_container):
     """Test add-files command"""
-    path = Path(temp_dir, "test.txt")
-    path.write_bytes(b"test")
+    path = Path(temp_dir, 'test.txt')
+    path.write_bytes(b'test')
     obj = cli.ContainerContext(temp_container.get_folder())
     result = CliRunner().invoke(cli.add_files, [str(path)], obj=obj)
     assert result.exit_code == 0, result.output
@@ -86,7 +87,7 @@ def test_add_file(temp_dir, temp_container):
 def test_optimize(temp_container):
     """Test optimize command"""
     temp_container.init_container(clear=True)
-    temp_container.add_object(b"test")
+    temp_container.add_object(b'test')
     assert temp_container.count_objects() == ObjectCount(
         loose=1,
         packed=0,
@@ -94,7 +95,7 @@ def test_optimize(temp_container):
     )
     temp_container.close()
     obj = cli.ContainerContext(temp_container.get_folder())
-    result = CliRunner().invoke(cli.optimize, ["--non-interactive"], obj=obj)
+    result = CliRunner().invoke(cli.optimize, ['--non-interactive'], obj=obj)
     assert result.exit_code == 0, result.output
     assert temp_container.count_objects() == ObjectCount(
         loose=0,
@@ -106,62 +107,62 @@ def test_optimize(temp_container):
 def test_optimize_cancel(temp_container):
     """Test cancelling optimize command"""
     obj = cli.ContainerContext(temp_container.get_folder())
-    result = CliRunner().invoke(cli.optimize, obj=obj, input="n")
+    result = CliRunner().invoke(cli.optimize, obj=obj, input='n')
     assert result.exit_code == 1, result.output
-    assert "Abort" in result.output
+    assert 'Abort' in result.output
 
 
-@pytest.mark.parametrize("verbose", [True, False])
+@pytest.mark.parametrize('verbose', [True, False])
 def test_validate(temp_container, verbose):
     """Test validate command"""
     temp_container.init_container(clear=True)
     # Add a few objects
     for idx in range(100):
-        temp_container.add_object(f"test-{idx}".encode())
+        temp_container.add_object(f'test-{idx}'.encode())
 
     obj = cli.ContainerContext(temp_container.get_folder())
     if verbose:
-        result = CliRunner().invoke(cli.validate, ["--verbose"], obj=obj)
+        result = CliRunner().invoke(cli.validate, ['--verbose'], obj=obj)
     else:
         result = CliRunner().invoke(cli.validate, obj=obj)
     assert result.exit_code == 0
-    assert "No errors found" in result.stdout
+    assert 'No errors found' in result.stdout
     if verbose:
         # Show progress bar
-        assert "100%" in result.stdout
+        assert '100%' in result.stdout
 
 
-@pytest.mark.parametrize("verbose", [True, False])
+@pytest.mark.parametrize('verbose', [True, False])
 def test_validate_fail(temp_container, verbose):
     """Test validate command"""
     temp_container.init_container(clear=True)
     # Add an object
-    hashkey = temp_container.add_object(b"test")
+    hashkey = temp_container.add_object(b'test')
     # Replace the object content with something different, so the hash does
     # not match anymore
     with open(
         temp_container._get_loose_path_from_hashkey(  # pylint: disable=protected-access
             hashkey
         ),
-        "wb",
+        'wb',
     ) as fhandle:
-        fhandle.write(b"wrong-content")
+        fhandle.write(b'wrong-content')
 
     obj = cli.ContainerContext(temp_container.get_folder())
     if verbose:
-        result = CliRunner().invoke(cli.validate, ["--verbose"], obj=obj)
+        result = CliRunner().invoke(cli.validate, ['--verbose'], obj=obj)
     else:
         result = CliRunner().invoke(cli.validate, obj=obj)
     assert result.exit_code != 0
     assert "1 objects with error 'invalid_hashes_loose'" in result.stdout
 
 
-@pytest.mark.parametrize("verbose", [True, False])
+@pytest.mark.parametrize('verbose', [True, False])
 def test_validate_no_progressbar(temp_container, verbose, monkeypatch):
     """Check the output when TQDM is not available (so no progress bar)."""
     temp_container.init_container(clear=True)
     # Add an object
-    temp_container.add_object(b"test")
+    temp_container.add_object(b'test')
 
     import builtins  # pylint: disable=import-outside-toplevel
 
@@ -169,35 +170,39 @@ def test_validate_no_progressbar(temp_container, verbose, monkeypatch):
 
     ## Disable importing tqdm with a monkey patch
     def myimport(
-        name, globals, locals, fromlist, level  # pylint: disable=redefined-builtin
+        name,
+        globals,
+        locals,
+        fromlist,
+        level,  # pylint: disable=redefined-builtin
     ):
-        if name == "tqdm":
+        if name == 'tqdm':
             raise ImportError("No module named 'tqdm'")
         return realimport(name, globals, locals, fromlist, level)
 
-    monkeypatch.setattr(builtins, "__import__", myimport)
+    monkeypatch.setattr(builtins, '__import__', myimport)
 
     obj = cli.ContainerContext(temp_container.get_folder())
     if verbose:
-        result = CliRunner().invoke(cli.validate, ["--verbose"], obj=obj)
+        result = CliRunner().invoke(cli.validate, ['--verbose'], obj=obj)
     else:
         result = CliRunner().invoke(cli.validate, obj=obj)
 
     assert result.exit_code == 0
-    assert "INFO: no `tqdm` package found" in result.stdout
-    assert "No errors found" in result.stdout
+    assert 'INFO: no `tqdm` package found' in result.stdout
+    assert 'No errors found' in result.stdout
 
 
 @pytest.mark.skipif(
-    platform.system() == "Windows", reason="Backup not supported on Windows"
+    platform.system() == 'Windows', reason='Backup not supported on Windows'
 )
 @pytest.mark.parametrize(
-    "remote, verbosity",
+    'remote, verbosity',
     [
         (False, None),
-        (False, "silent"),
-        (False, "info"),
-        (False, "debug"),
+        (False, 'silent'),
+        (False, 'info'),
+        (False, 'debug'),
         (True, None),
     ],
 )
@@ -207,21 +212,21 @@ def test_backup(temp_container, temp_dir, remote, verbosity):
     temp_container.init_container(clear=True)
     # Add a few objects
     for idx in range(100):
-        temp_container.add_object(f"test-{idx}".encode())
+        temp_container.add_object(f'test-{idx}'.encode())
 
     obj = cli.ContainerContext(temp_container.get_folder())
 
-    path = Path(temp_dir) / "backup"
+    path = Path(temp_dir) / 'backup'
 
     if remote:
-        destination = f"localhost:{str(path)}"
+        destination = f'localhost:{path!s}'
     else:
         destination = str(path)
 
     args = [destination]
 
     if verbosity:
-        args += [f"--verbosity={verbosity}"]
+        args += [f'--verbosity={verbosity}']
 
     result = CliRunner().invoke(cli.backup, args, obj=obj, catch_exceptions=False)
 
@@ -230,15 +235,15 @@ def test_backup(temp_container, temp_dir, remote, verbosity):
 
     path_contents = [entry.name for entry in path.iterdir()]
     backup_dirs = [
-        entry for entry in path.iterdir() if entry.name.startswith("backup_")
+        entry for entry in path.iterdir() if entry.name.startswith('backup_')
     ]
 
-    assert "last-backup" in path_contents
+    assert 'last-backup' in path_contents
     assert len(backup_dirs) == 1
 
     backup_dir_contents = [entry.name for entry in backup_dirs[0].iterdir()]
 
-    for item in ["config.json", "duplicates", "loose", "packs", "packs.idx", "sandbox"]:
+    for item in ['config.json', 'duplicates', 'loose', 'packs', 'packs.idx', 'sandbox']:
         assert item in backup_dir_contents
 
     # validate the backup
@@ -247,13 +252,13 @@ def test_backup(temp_container, temp_dir, remote, verbosity):
     result = CliRunner().invoke(cli.validate, obj=obj)
 
     assert result.exit_code == 0
-    assert "No errors found" in result.stdout
+    assert 'No errors found' in result.stdout
 
 
 @pytest.mark.skipif(
-    platform.system() == "Windows", reason="Backup not supported on Windows"
+    platform.system() == 'Windows', reason='Backup not supported on Windows'
 )
-@pytest.mark.parametrize("remote", [False, True])
+@pytest.mark.parametrize('remote', [False, True])
 def test_backup_repeated(temp_container, temp_dir, remote):
     """Test the backup command repeated 3 times.
 
@@ -263,14 +268,14 @@ def test_backup_repeated(temp_container, temp_dir, remote):
     temp_container.init_container(clear=True)
     # Add a few objects
     for idx in range(100):
-        temp_container.add_object(f"test-{idx}".encode())
+        temp_container.add_object(f'test-{idx}'.encode())
 
     obj = cli.ContainerContext(temp_container.get_folder())
 
-    path = Path(temp_dir) / "backup"
+    path = Path(temp_dir) / 'backup'
 
     if remote:
-        destination = f"localhost:{str(path)}"
+        destination = f'localhost:{path!s}'
     else:
         destination = str(path)
 
@@ -281,15 +286,15 @@ def test_backup_repeated(temp_container, temp_dir, remote):
     assert path.exists()
     path_contents = [entry.name for entry in path.iterdir()]
     backup_dirs = [
-        entry for entry in path.iterdir() if entry.name.startswith("backup_")
+        entry for entry in path.iterdir() if entry.name.startswith('backup_')
     ]
 
-    assert "last-backup" in path_contents
+    assert 'last-backup' in path_contents
     assert len(backup_dirs) == 2
 
 
 @pytest.mark.skipif(
-    platform.system() == "Windows", reason="Backup not supported on Windows"
+    platform.system() == 'Windows', reason='Backup not supported on Windows'
 )
 def test_backup_failure(temp_container):
     """Test failure when providing invalid destination"""
@@ -297,13 +302,13 @@ def test_backup_failure(temp_container):
     temp_container.init_container(clear=True)
     # Add a few objects
     for idx in range(100):
-        temp_container.add_object(f"test-{idx}".encode())
+        temp_container.add_object(f'test-{idx}'.encode())
 
     obj = cli.ContainerContext(temp_container.get_folder())
 
-    dest = "abc:abc:"
+    dest = 'abc:abc:'
 
     result = CliRunner().invoke(cli.backup, [dest], obj=obj)
 
     assert result.exit_code == 1
-    assert "Error:" in result.stdout
+    assert 'Error:' in result.stdout

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -18,9 +18,7 @@ NUM_WORKERS = 4
 # Do the same test multiple times (repetition*2*2); can be set to > 1 to increase probability of seeing problems.
 # This is specified on the command line when running pytest with ``--concurrency-repetitions=VALUE``
 # (VALUE=1 by default) and passed as `concurrency_repetition_index`.
-@pytest.mark.parametrize(
-    'with_packing', [True, False]
-)  # If it works with packing, no need to test also without
+@pytest.mark.parametrize('with_packing', [True, False])  # If it works with packing, no need to test also without
 @pytest.mark.parametrize('max_size', [1, 1000])
 def test_concurrency(  # pylint: disable=too-many-statements, too-many-locals, unused-argument
     temp_dir, with_packing, max_size, concurrency_repetition_index
@@ -118,9 +116,7 @@ def test_concurrency(  # pylint: disable=too-many-statements, too-many-locals, u
     error_messages = []
 
     if with_packing and packer_proc.returncode:
-        error_messages.append(
-            f'PACKER process failed with error code {packer_proc.returncode}!'
-        )
+        error_messages.append(f'PACKER process failed with error code {packer_proc.returncode}!')
         error_messages.append('PACKER output:')
         error_messages.append(packer_out.decode('utf8'))
         error_messages.append('-' * 78)
@@ -128,13 +124,9 @@ def test_concurrency(  # pylint: disable=too-many-statements, too-many-locals, u
         error_messages.append(packer_err.decode('utf8'))
         error_messages.append('=' * 78)
 
-    for idx, (worker_proc, worker_out, worker_err) in enumerate(
-        zip(worker_procs, worker_outs, worker_errs)
-    ):
+    for idx, (worker_proc, worker_out, worker_err) in enumerate(zip(worker_procs, worker_outs, worker_errs)):
         if worker_proc.returncode:
-            error_messages.append(
-                f'WORKER process #{idx} failed with error code {worker_proc.returncode}!'
-            )
+            error_messages.append(f'WORKER process #{idx} failed with error code {worker_proc.returncode}!')
             error_messages.append(f'WORKER {idx} output:')
             error_messages.append(worker_out.decode('utf8'))
             error_messages.append('-' * 78)
@@ -142,8 +134,5 @@ def test_concurrency(  # pylint: disable=too-many-statements, too-many-locals, u
             error_messages.append(worker_err.decode('utf8'))
             error_messages.append('=' * 78)
 
-    error_string = (
-        'At least one of the concurrent processes failed!\nMessages:\n'
-        + '\n'.join(error_messages)
-    )
+    error_string = 'At least one of the concurrent processes failed!\nMessages:\n' + '\n'.join(error_messages)
     assert len(error_messages) == 0, error_string

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,4 +1,5 @@
 """Test of the object-store container module."""
+
 import os
 import subprocess
 import sys
@@ -9,7 +10,7 @@ import pytest
 from disk_objectstore import Container
 
 THIS_FILE_DIR = Path(__file__).parent
-CONCURRENT_DIR = THIS_FILE_DIR / "concurrent_tests"
+CONCURRENT_DIR = THIS_FILE_DIR / 'concurrent_tests'
 
 NUM_WORKERS = 4
 
@@ -18,9 +19,9 @@ NUM_WORKERS = 4
 # This is specified on the command line when running pytest with ``--concurrency-repetitions=VALUE``
 # (VALUE=1 by default) and passed as `concurrency_repetition_index`.
 @pytest.mark.parametrize(
-    "with_packing", [True, False]
+    'with_packing', [True, False]
 )  # If it works with packing, no need to test also without
-@pytest.mark.parametrize("max_size", [1, 1000])
+@pytest.mark.parametrize('max_size', [1, 1000])
 def test_concurrency(  # pylint: disable=too-many-statements, too-many-locals, unused-argument
     temp_dir, with_packing, max_size, concurrency_repetition_index
 ):
@@ -37,16 +38,16 @@ def test_concurrency(  # pylint: disable=too-many-statements, too-many-locals, u
     ``concurrency_repetition_index`` is an integer looking over the specified repetitions on the pytest command line.
     We don't use this variable, it's just used to repeat the run multiple times.
     """
-    packer_script = CONCURRENT_DIR / "periodic_packer.py"
-    worker_script = CONCURRENT_DIR / "periodic_worker.py"
+    packer_script = CONCURRENT_DIR / 'periodic_packer.py'
+    worker_script = CONCURRENT_DIR / 'periodic_worker.py'
 
     # Create folder with the container and initialise it
-    container_dir = temp_dir / "container"
+    container_dir = temp_dir / 'container'
     Container(container_dir).init_container()
 
     # Create folder where each worker will write the MD5 of the objects it created,
     # so that others will read them.
-    shared_dir = temp_dir / "shared"
+    shared_dir = temp_dir / 'shared'
     os.mkdir(shared_dir)
 
     if with_packing:
@@ -55,12 +56,12 @@ def test_concurrency(  # pylint: disable=too-many-statements, too-many-locals, u
             [
                 sys.executable,
                 packer_script,
-                "-p",
+                '-p',
                 container_dir,
-                "-r",
-                "7",
-                "-w",
-                "0.83",
+                '-r',
+                '7',
+                '-w',
+                '0.83',
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -70,20 +71,20 @@ def test_concurrency(  # pylint: disable=too-many-statements, too-many-locals, u
     worker_procs = []
     for worker_id in range(NUM_WORKERS):
         options = [
-            "-r",
-            "6",
-            "-w",
-            "0",
-            "-p",
+            '-r',
+            '6',
+            '-w',
+            '0',
+            '-p',
             container_dir,
-            "-s",
+            '-s',
             shared_dir,
-            "-M",
+            '-M',
             str(max_size),
         ]
         if worker_id % 2:
             # One every two will read in bulk, the other within a loop
-            options += ["-b"]
+            options += ['-b']
         worker_procs.append(
             subprocess.Popen(  # pylint: disable=consider-using-with
                 [sys.executable, worker_script] + options,
@@ -95,11 +96,11 @@ def test_concurrency(  # pylint: disable=too-many-statements, too-many-locals, u
     if with_packing:
         packer_out, packer_err = packer_proc.communicate()
         if packer_out:
-            print("** STDOUT OF PACKER")
-            print(packer_out.decode("utf8"))
+            print('** STDOUT OF PACKER')
+            print(packer_out.decode('utf8'))
         if packer_err:
-            print("** STDERR OF PACKER")
-            print(packer_err.decode("utf8"), file=sys.stderr)
+            print('** STDERR OF PACKER')
+            print(packer_err.decode('utf8'), file=sys.stderr)
 
     worker_outs = []
     worker_errs = []
@@ -108,41 +109,41 @@ def test_concurrency(  # pylint: disable=too-many-statements, too-many-locals, u
         worker_outs.append(worker_out)
         worker_errs.append(worker_err)
         if worker_out:
-            print(f"** STDOUT OF WORKER {worker_id}")
-            print(worker_out.decode("utf8"))
+            print(f'** STDOUT OF WORKER {worker_id}')
+            print(worker_out.decode('utf8'))
         if worker_err:
-            print(f"** STDERR OF WORKER {worker_id}", file=sys.stderr)
-            print(worker_err.decode("utf8"), file=sys.stderr)
+            print(f'** STDERR OF WORKER {worker_id}', file=sys.stderr)
+            print(worker_err.decode('utf8'), file=sys.stderr)
 
     error_messages = []
 
     if with_packing and packer_proc.returncode:
         error_messages.append(
-            f"PACKER process failed with error code {packer_proc.returncode}!"
+            f'PACKER process failed with error code {packer_proc.returncode}!'
         )
-        error_messages.append("PACKER output:")
-        error_messages.append(packer_out.decode("utf8"))
-        error_messages.append("-" * 78)
-        error_messages.append("PACKER error:")
-        error_messages.append(packer_err.decode("utf8"))
-        error_messages.append("=" * 78)
+        error_messages.append('PACKER output:')
+        error_messages.append(packer_out.decode('utf8'))
+        error_messages.append('-' * 78)
+        error_messages.append('PACKER error:')
+        error_messages.append(packer_err.decode('utf8'))
+        error_messages.append('=' * 78)
 
     for idx, (worker_proc, worker_out, worker_err) in enumerate(
         zip(worker_procs, worker_outs, worker_errs)
     ):
         if worker_proc.returncode:
             error_messages.append(
-                f"WORKER process #{idx} failed with error code {worker_proc.returncode}!"
+                f'WORKER process #{idx} failed with error code {worker_proc.returncode}!'
             )
-            error_messages.append(f"WORKER {idx} output:")
-            error_messages.append(worker_out.decode("utf8"))
-            error_messages.append("-" * 78)
-            error_messages.append(f"WORKER {idx} error:")
-            error_messages.append(worker_err.decode("utf8"))
-            error_messages.append("=" * 78)
+            error_messages.append(f'WORKER {idx} output:')
+            error_messages.append(worker_out.decode('utf8'))
+            error_messages.append('-' * 78)
+            error_messages.append(f'WORKER {idx} error:')
+            error_messages.append(worker_err.decode('utf8'))
+            error_messages.append('=' * 78)
 
     error_string = (
-        "At least one of the concurrent processes failed!\nMessages:\n"
-        + "\n".join(error_messages)
+        'At least one of the concurrent processes failed!\nMessages:\n'
+        + '\n'.join(error_messages)
     )
     assert len(error_messages) == 0, error_string

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -129,8 +129,8 @@ def test_add_get_loose(temp_container, generate_random_data, retrieve_bulk):
         counts['packed'] == 0
     ), f"The container should have no packed objects (but there are {counts['packed']} instead)"
     # I check with the length of the set because I could have picked to random identical objects
-    assert (
-        counts['loose'] == len(set(obj_md5s))
+    assert counts['loose'] == len(
+        set(obj_md5s)
     ), f"The container should have {len(set(obj_md5s))} loose objects (but there are {counts['loose']} instead)"
 
     # Retrieve objects (loose), in random order
@@ -174,9 +174,7 @@ def test_add_loose_from_stream(temp_container):
     'use_compression,retrieve_bulk',
     [(True, True), (True, False), (False, True), (False, False)],
 )
-def test_add_get_with_packing(
-    temp_container, generate_random_data, use_compression, retrieve_bulk
-):
+def test_add_get_with_packing(temp_container, generate_random_data, use_compression, retrieve_bulk):
     """Add a number of objects (one by one, loose) to the container.
 
     Then retrieve them and check the content is correct."""
@@ -191,8 +189,8 @@ def test_add_get_with_packing(
     temp_container.pack_all_loose(compress=use_compression)
 
     counts = temp_container.count_objects()
-    assert (
-        counts['packed'] == len(set(obj_md5s))
+    assert counts['packed'] == len(
+        set(obj_md5s)
     ), f"The container should have {len(set(obj_md5s))} packed objects (but there are {counts['packed']} instead)"
     # Loose objects are not immediately deleted
     assert counts['loose'] == len(set(obj_md5s)), (
@@ -204,9 +202,7 @@ def test_add_get_with_packing(
     temp_container.clean_storage()
     counts = temp_container.count_objects()
     # Now there shouldn't be any more loose objects
-    assert (
-        counts['loose'] == 0
-    ), f"The container should have 0 loose objects (but there are {counts['loose']} instead)"
+    assert counts['loose'] == 0, f"The container should have 0 loose objects (but there are {counts['loose']} instead)"
 
     # Retrieve objects (loose), in random order
     random_keys = list(obj_md5s.keys())
@@ -228,9 +224,7 @@ def test_add_get_with_packing(
 
 
 @pytest.mark.parametrize('use_compression', [True, False])
-def test_directly_to_pack_content(
-    temp_container, generate_random_data, use_compression
-):
+def test_directly_to_pack_content(temp_container, generate_random_data, use_compression):
     """Add a number of objects directly to packs.
 
     Then retrieve them and check the content is correct (always bulk retrieve for simplicity).
@@ -239,17 +233,13 @@ def test_directly_to_pack_content(
 
     data = generate_random_data()
 
-    obj_md5s = _add_objects_directly_to_pack(
-        temp_container, data, compress=use_compression
-    )
+    obj_md5s = _add_objects_directly_to_pack(temp_container, data, compress=use_compression)
 
     counts = temp_container.count_objects()
-    assert (
-        counts['packed'] == len(set(data))
+    assert counts['packed'] == len(
+        set(data)
     ), f"The container should have {len(set(data))} packed objects (but there are {counts['packed']} instead)"
-    assert (
-        counts['loose'] == 0
-    ), f"The container should have 0 loose objects (but there are {counts['loose']} instead)"
+    assert counts['loose'] == 0, f"The container should have 0 loose objects (but there are {counts['loose']} instead)"
 
     # Retrieve objects (loose), in random order
     random_keys = list(obj_md5s.keys())
@@ -362,9 +352,7 @@ def test_container_context_manager(temp_dir):
         container.add_object(b'abc')
         container.pack_all_loose()
         assert container._operation_session is not None, 'Session should be open'
-    assert (
-        container._operation_session is None
-    ), 'Session should be closed when going out of the context manager'
+    assert container._operation_session is None, 'Session should be closed when going out of the context manager'
 
 
 def test_num_packs_with_target_size(temp_dir, generate_random_data):
@@ -405,9 +393,7 @@ def test_num_packs_with_target_size(temp_dir, generate_random_data):
     # Because of the length, they are surely different from previous data
     # Also, it's bigger than the pack_size_target.
     new_obj = list(
-        generate_random_data(
-            num_files=1, min_size=pack_size_target * 2, max_size=pack_size_target * 2
-        ).values()
+        generate_random_data(num_files=1, min_size=pack_size_target * 2, max_size=pack_size_target * 2).values()
     )[0]
     # Create three objects from this template, with different suffix, so hash key is different
     new_obj1 = new_obj + b'1'
@@ -447,9 +433,7 @@ def test_num_packs_with_target_size(temp_dir, generate_random_data):
     'use_compression,open_streams',
     [(True, True), (True, False), (False, True), (False, False)],
 )
-def test_directly_to_pack_streamed(
-    temp_dir, generate_random_data, use_compression, open_streams, pack_size_target
-):  # pylint: disable=too-many-locals
+def test_directly_to_pack_streamed(temp_dir, generate_random_data, use_compression, open_streams, pack_size_target):  # pylint: disable=too-many-locals
     """Add a number of objects directly to packs, using streams.
 
     Then retrieve them and check the content is correct (always bulk retrieve for simplicity).
@@ -480,9 +464,7 @@ def test_directly_to_pack_streamed(
             # I check that instead it fails if I forget to open the streams (and that it does not create side effects)
             # The error that I get here would be: "LazyOpener' object has no attribute 'read'"
             with pytest.raises(AttributeError):
-                temp_container.add_streamed_objects_to_pack(
-                    streams_copy, compress=use_compression, open_streams=False
-                )
+                temp_container.add_streamed_objects_to_pack(streams_copy, compress=use_compression, open_streams=False)
 
     else:
         streams = [UnopenableBytesIO(value) for value in values]
@@ -494,19 +476,15 @@ def test_directly_to_pack_streamed(
         # (and that it does not create side effects). Note that I disabled explicitly the __enter__ method
         # in the class UnopenableBytesIO to make sure that this raises
         with pytest.raises(AttributeError):
-            temp_container.add_streamed_objects_to_pack(
-                streams_copy, compress=use_compression, open_streams=True
-            )
+            temp_container.add_streamed_objects_to_pack(streams_copy, compress=use_compression, open_streams=True)
 
     obj_md5s = dict(zip(obj_hashkeys, keys))
 
     counts = temp_container.count_objects()
-    assert (
-        counts['packed'] == len(set(data))
+    assert counts['packed'] == len(
+        set(data)
     ), f"The container should have {len(set(data))} packed objects (but there are {counts['packed']} instead)"
-    assert (
-        counts['loose'] == 0
-    ), f"The container should have 0 loose objects (but there are {counts['loose']} instead)"
+    assert counts['loose'] == 0, f"The container should have 0 loose objects (but there are {counts['loose']} instead)"
 
     # Retrieve objects (loose), in random order
     random_keys = list(obj_md5s.keys())
@@ -531,14 +509,10 @@ def test_directly_to_pack_streamed(
     'loose_prefix_len,pack_size_target',
     [(0, 1000), (2, 1000), (3, 1000), (0, 40000000), (2, 40000000), (3, 40000000)],
 )
-def test_prefix_lengths(
-    temp_dir, generate_random_data, pack_size_target, loose_prefix_len
-):
+def test_prefix_lengths(temp_dir, generate_random_data, pack_size_target, loose_prefix_len):
     """Check if the loose prefix length are honored, and if everything works also with vey small pack size target."""
     container = Container(temp_dir)
-    container.init_container(
-        clear=True, pack_size_target=pack_size_target, loose_prefix_len=loose_prefix_len
-    )
+    container.init_container(clear=True, pack_size_target=pack_size_target, loose_prefix_len=loose_prefix_len)
     # Check that the `get_folder` method returns the expected folder name
     assert container.get_folder() == temp_dir.resolve()
 
@@ -566,8 +540,8 @@ def test_prefix_lengths(
     assert (
         counts['packed'] == 0
     ), f"The container should have 0 packed objects (but there are {counts['packed']} instead)"
-    assert (
-        counts['loose'] == len(set(obj_md5s))
+    assert counts['loose'] == len(
+        set(obj_md5s)
     ), f"The container should have {len(set(obj_md5s))} loose objects (but there are {counts['loose']} instead)"
 
     retrieved_md5s = _get_data_and_md5_bulk(container, obj_md5s.keys())
@@ -590,8 +564,8 @@ def test_prefix_lengths(
     )
 
     counts = container.count_objects()
-    assert (
-        counts['packed'] == len(set(obj_md5s))
+    assert counts['packed'] == len(
+        set(obj_md5s)
     ), f"The container should have {len(set(obj_md5s))} packed objects (but there are {counts['packed']} instead)"
     # Loose objects are not immediately deleted
     assert counts['loose'] == len(set(obj_md5s)), (
@@ -603,9 +577,7 @@ def test_prefix_lengths(
     container.clean_storage()
     counts = container.count_objects()
     # Now there shouldn't be any more loose objects
-    assert (
-        counts['loose'] == 0
-    ), f"The container should have 0 loose objects (but there are {counts['loose']} instead)"
+    assert counts['loose'] == 0, f"The container should have 0 loose objects (but there are {counts['loose']} instead)"
 
     retrieved_md5s = _get_data_and_md5_bulk(container, obj_md5s.keys())
     # Check that the MD5 are correct
@@ -627,17 +599,11 @@ def test_prefix_lengths(
     for pack_id in valid_pack_ids:
         assert container._is_valid_pack_id(pack_id), f"'{pack_id}' should be valid"
     for pack_id in invalid_pack_ids:
-        assert not container._is_valid_pack_id(
-            pack_id
-        ), f"'{pack_id}' should be invalid"
+        assert not container._is_valid_pack_id(pack_id), f"'{pack_id}' should be invalid"
     for loose_prefix in valid_loose_prefixes:
-        assert container._is_valid_loose_prefix(
-            loose_prefix
-        ), f"'{loose_prefix}' should be valid"
+        assert container._is_valid_loose_prefix(loose_prefix), f"'{loose_prefix}' should be valid"
     for loose_prefix in invalid_loose_prefixes:
-        assert not container._is_valid_loose_prefix(
-            loose_prefix
-        ), f"'{loose_prefix}' should be invalid"
+        assert not container._is_valid_loose_prefix(loose_prefix), f"'{loose_prefix}' should be invalid"
 
     # I close the container, as this is needed on Windows
     container.close()
@@ -762,22 +728,16 @@ def test_validation_while_packing(temp_container, compress, corrupt, validate_ob
 
     # Corrupt the content of a loose object
     if corrupt:
-        with open(
-            temp_container._get_loose_path_from_hashkey(hashkey2), 'wb'
-        ) as fhandle:
+        with open(temp_container._get_loose_path_from_hashkey(hashkey2), 'wb') as fhandle:
             fhandle.write(corrupted_content2)
 
     if corrupt and validate_objects:
         with pytest.raises(exc.InconsistentContent):
-            temp_container.pack_all_loose(
-                compress=compress, validate_objects=validate_objects
-            )
+            temp_container.pack_all_loose(compress=compress, validate_objects=validate_objects)
         # hashkey2 should have been left as 'loose'. Hashkey1 could be either packed or loose, so we don't check.
         assert temp_container.get_object_meta(hashkey2)['type'] == ObjectType.LOOSE
     else:
-        temp_container.pack_all_loose(
-            compress=compress, validate_objects=validate_objects
-        )
+        temp_container.pack_all_loose(compress=compress, validate_objects=validate_objects)
         # Both should have been packed
         assert temp_container.get_object_meta(hashkey1)['type'] == ObjectType.PACKED
         assert temp_container.get_object_meta(hashkey2)['type'] == ObjectType.PACKED
@@ -792,12 +752,8 @@ def test_validation_while_packing(temp_container, compress, corrupt, validate_ob
 
 
 # Only three options: if pack_objects is False, the values of compress_packs is ignored
-@pytest.mark.parametrize(
-    'pack_objects,compress_packs', [(True, True), (True, False), (False, False)]
-)
-def test_unknown_hashkeys(
-    temp_container, generate_random_data, pack_objects, compress_packs
-):
+@pytest.mark.parametrize('pack_objects,compress_packs', [(True, True), (True, False), (False, False)])
+def test_unknown_hashkeys(temp_container, generate_random_data, pack_objects, compress_packs):
     """Put some data in the container, then check that unknown hash keys raise the correct error."""
     # Generate and store some data, just not to have an empty container
     data = generate_random_data()
@@ -842,9 +798,7 @@ def test_unknown_hashkeys(
     # skip_if_missing=True, get streams
     missing = []
     check_md5s = {}
-    with temp_container.get_objects_stream_and_meta(
-        hashkeys_list, skip_if_missing=True
-    ) as triplets:
+    with temp_container.get_objects_stream_and_meta(hashkeys_list, skip_if_missing=True) as triplets:
         for obj_hashkey, stream, meta in triplets:
             if stream is None:
                 assert meta['size'] is None
@@ -871,9 +825,7 @@ def test_unknown_hashkeys(
     # skip_if_missing=False, get streams
     missing = []
     check_md5s = {}
-    with temp_container.get_objects_stream_and_meta(
-        hashkeys_list, skip_if_missing=False
-    ) as triplets:
+    with temp_container.get_objects_stream_and_meta(hashkeys_list, skip_if_missing=False) as triplets:
         for obj_hashkey, stream, meta in triplets:
             if stream is None:
                 assert meta['size'] is None
@@ -944,9 +896,7 @@ def test_same_object_direct_pack(temp_container, generate_random_data):
     # Do it again; the object is already there
     new_obj_hashkeys = temp_container.add_objects_to_pack(all_test_data)
     assert len(set(obj_hashkeys)) == 1, 'Objects are not all identical'
-    assert (
-        obj_hashkeys[0] == new_obj_hashkeys[0]
-    ), 'In the second insertion, it generated a different hash key'
+    assert obj_hashkeys[0] == new_obj_hashkeys[0], 'In the second insertion, it generated a different hash key'
 
     # Check the number of objects again
     counts = temp_container.count_objects()
@@ -1063,21 +1013,14 @@ def test_locked_object_while_packing(  # pylint: disable=invalid-name
 # level as a keyword argument, as this was added only in python 3.6
 @pytest.mark.parametrize('compression_algorithm', COMPRESSION_ALGORITHMS_TO_TEST)
 @pytest.mark.parametrize('compress_packs', [True, False])
-def test_sizes(
-    temp_container, generate_random_data, compress_packs, compression_algorithm
-):
+def test_sizes(temp_container, generate_random_data, compress_packs, compression_algorithm):
     """Check that the information on size is reliable."""
-    temp_container.init_container(
-        clear=True, compression_algorithm=compression_algorithm
-    )
+    temp_container.init_container(clear=True, compression_algorithm=compression_algorithm)
     size_info = temp_container.get_total_size()
     assert size_info['total_size_packed'] == 0
     assert size_info['total_size_packed_on_disk'] == 0
     assert size_info['total_size_packfiles_on_disk'] == 0
-    assert (
-        size_info['total_size_packindexes_on_disk']
-        == temp_container._get_pack_index_path().stat().st_size
-    )
+    assert size_info['total_size_packindexes_on_disk'] == temp_container._get_pack_index_path().stat().st_size
     assert size_info['total_size_loose'] == 0
 
     data = generate_random_data()
@@ -1085,10 +1028,7 @@ def test_sizes(
     obj_md5s = _add_objects_loose_loop(temp_container, data)
     # Try to count size after retrieving, just to be sure
     assert (
-        sum(
-            len(content)
-            for content in temp_container.get_objects_content(obj_md5s.keys()).values()
-        )
+        sum(len(content) for content in temp_container.get_objects_content(obj_md5s.keys()).values())
         == total_object_size
     )
 
@@ -1097,10 +1037,7 @@ def test_sizes(
     assert size_info['total_size_packed'] == 0
     assert size_info['total_size_packed_on_disk'] == 0
     assert size_info['total_size_packfiles_on_disk'] == 0
-    assert (
-        size_info['total_size_packindexes_on_disk']
-        == temp_container._get_pack_index_path().stat().st_size
-    )
+    assert size_info['total_size_packindexes_on_disk'] == temp_container._get_pack_index_path().stat().st_size
     assert size_info['total_size_loose'] == total_object_size
 
     # Pack without compression
@@ -1110,10 +1047,7 @@ def test_sizes(
 
     # Try to count size after retrieving, just to be sure
     assert (
-        sum(
-            len(content)
-            for content in temp_container.get_objects_content(obj_md5s.keys()).values()
-        )
+        sum(len(content) for content in temp_container.get_objects_content(obj_md5s.keys()).values())
         == total_object_size
     )
 
@@ -1130,20 +1064,14 @@ def test_sizes(
         assert size_info['total_size_packed'] == total_object_size
         assert size_info['total_size_packed_on_disk'] == total_compressed_size
         assert size_info['total_size_packfiles_on_disk'] == total_compressed_size
-        assert (
-            size_info['total_size_packindexes_on_disk']
-            == temp_container._get_pack_index_path().stat().st_size
-        )
+        assert size_info['total_size_packindexes_on_disk'] == temp_container._get_pack_index_path().stat().st_size
         assert size_info['total_size_loose'] == 0
     else:
         size_info = temp_container.get_total_size()
         assert size_info['total_size_packed'] == total_object_size
         assert size_info['total_size_packed_on_disk'] == total_object_size
         assert size_info['total_size_packfiles_on_disk'] == total_object_size
-        assert (
-            size_info['total_size_packindexes_on_disk']
-            == temp_container._get_pack_index_path().stat().st_size
-        )
+        assert size_info['total_size_packindexes_on_disk'] == temp_container._get_pack_index_path().stat().st_size
         assert size_info['total_size_loose'] == 0
 
 
@@ -1185,18 +1113,14 @@ def test_get_objects_stream_closes(temp_dir, generate_random_data):
 
         start_open_files = len(current_process.open_files())
 
-        with temp_container.get_objects_stream_and_meta(
-            obj_md5s.keys(), skip_if_missing=True
-        ):
+        with temp_container.get_objects_stream_and_meta(obj_md5s.keys(), skip_if_missing=True):
             # I don't use the triplets
             assert len(current_process.open_files()) <= start_open_files + 1
 
         # Check that at the end nothing is left open
         assert len(current_process.open_files()) == start_open_files
 
-        with temp_container.get_objects_stream_and_meta(
-            obj_md5s.keys(), skip_if_missing=True
-        ) as triplets:
+        with temp_container.get_objects_stream_and_meta(obj_md5s.keys(), skip_if_missing=True) as triplets:
             # I loop over the triplets, but I don't do anything
             for _ in triplets:  # pylint: disable=not-an-iterable
                 assert len(current_process.open_files()) <= start_open_files + 1
@@ -1205,9 +1129,7 @@ def test_get_objects_stream_closes(temp_dir, generate_random_data):
         assert len(current_process.open_files()) == start_open_files
 
         # I actually read the content
-        with temp_container.get_objects_stream_and_meta(
-            obj_md5s.keys(), skip_if_missing=True
-        ) as triplets:
+        with temp_container.get_objects_stream_and_meta(obj_md5s.keys(), skip_if_missing=True) as triplets:
             # I loop over the triplets, but I don't do anything
             for _, stream, _ in triplets:  # pylint: disable=not-an-iterable
                 assert len(current_process.open_files()) <= start_open_files + 1
@@ -1241,9 +1163,7 @@ def test_get_objects_stream_closes(temp_dir, generate_random_data):
         assert len(current_process.open_files()) == start_open_files
 
         # I actually read the content
-        with temp_container.get_objects_stream_and_meta(
-            obj_md5s.keys(), skip_if_missing=True
-        ) as triplets:
+        with temp_container.get_objects_stream_and_meta(obj_md5s.keys(), skip_if_missing=True) as triplets:
             # I loop over the triplets, but I don't do anything
             for _, stream, _ in triplets:  # pylint: disable=not-an-iterable
                 assert len(current_process.open_files()) <= start_open_files + 1
@@ -1254,9 +1174,7 @@ def test_get_objects_stream_closes(temp_dir, generate_random_data):
         ##############################
         ##### Same test after adding at least one loose object
         ##############################
-        new_object_content = (
-            b'1' * 20000
-        )  # This should be long enough not to collide with the generated random data
+        new_object_content = b'1' * 20000  # This should be long enough not to collide with the generated random data
         new_hashkey = temp_container.add_object(new_object_content)
         obj_md5s[new_hashkey] = new_object_content
 
@@ -1281,9 +1199,7 @@ def test_get_objects_stream_closes(temp_dir, generate_random_data):
         assert len(current_process.open_files()) == start_open_files
 
         # I actually read the content
-        with temp_container.get_objects_stream_and_meta(
-            obj_md5s.keys(), skip_if_missing=True
-        ) as triplets:
+        with temp_container.get_objects_stream_and_meta(obj_md5s.keys(), skip_if_missing=True) as triplets:
             # I loop over the triplets, but I don't do anything
             for _, stream, _ in triplets:  # pylint: disable=not-an-iterable
                 assert len(current_process.open_files()) <= start_open_files + 1
@@ -1315,9 +1231,7 @@ def test_deletion_closes_file_descriptors(temp_dir, generate_random_data):
         _ = temp_container.get_objects_content(obj_md5s.keys())
 
         # Checks if initalisation actually opens files
-        assert 0 < len(
-            current_process.open_files()
-        ), 'No files have been opened during initalisation'
+        assert 0 < len(current_process.open_files()), 'No files have been opened during initalisation'
 
         # Checks if deleting the container will close the files
         del temp_container
@@ -1370,9 +1284,7 @@ def test_get_objects_meta_doesnt_open(temp_container, generate_random_data):  # 
     ##############################
     ##### Same test after adding at least one loose object
     ##############################
-    new_object_content = (
-        b'1' * 20000
-    )  # This should be long enough not to collide with the generated random data
+    new_object_content = b'1' * 20000  # This should be long enough not to collide with the generated random data
     new_hashkey = temp_container.add_object(new_object_content)
     obj_md5s[new_hashkey] = new_object_content
 
@@ -1398,9 +1310,7 @@ def test_stream_meta(  # pylint: disable=too-many-locals
     temp_container, compress, skip_if_missing, compression_algorithm
 ):
     """Validate the meta dictionary returned by the get_objects_stream_and_meta and get_objects_meta."""
-    temp_container.init_container(
-        clear=True, compression_algorithm=compression_algorithm
-    )
+    temp_container.init_container(clear=True, compression_algorithm=compression_algorithm)
     # This is the list of all known meta keys.
     # I do also an explicit check that all and only these are present
     # This is implicit since I will later also compare the exact dictionaries and not only their keys,
@@ -1417,17 +1327,13 @@ def test_stream_meta(  # pylint: disable=too-many-locals
 
     content_packed = b'sffssdf383939'
     content_loose = b'v9fpaM'
-    hashkey_packed = temp_container.add_objects_to_pack(
-        [content_packed], compress=compress
-    )[0]
+    hashkey_packed = temp_container.add_objects_to_pack([content_packed], compress=compress)[0]
     hashkey_loose = temp_container.add_object(content_loose)
     hashkey_missing = 'unknown'
     compresser = utils.get_compressobj_instance(compression_algorithm)
     content_packed_compressed = compresser.compress(content_packed)
     content_packed_compressed += compresser.flush()
-    object_pack_length = (
-        len(content_packed) if not compress else len(content_packed_compressed)
-    )
+    object_pack_length = len(content_packed) if not compress else len(content_packed_compressed)
 
     expected_skip_missing_true = {
         hashkey_packed: {
@@ -1497,13 +1403,9 @@ def test_stream_meta(  # pylint: disable=too-many-locals
         check_dict[hashkey] = meta
 
     if skip_if_missing:
-        assert check_dict == {
-            k: v['meta'] for k, v in expected_skip_missing_true.items()
-        }
+        assert check_dict == {k: v['meta'] for k, v in expected_skip_missing_true.items()}
     else:
-        assert check_dict == {
-            k: v['meta'] for k, v in expected_skip_missing_false.items()
-        }
+        assert check_dict == {k: v['meta'] for k, v in expected_skip_missing_false.items()}
 
 
 # Note that until when we want to support py3.5, we cannot specify the
@@ -1514,9 +1416,7 @@ def test_stream_meta_single(temp_container, compress, compression_algorithm):
     """Validate the meta dictionary returned by the single-object methods.
 
     (i.e., get_object_stream_and_meta and get_object_meta)."""
-    temp_container.init_container(
-        clear=True, compression_algorithm=compression_algorithm
-    )
+    temp_container.init_container(clear=True, compression_algorithm=compression_algorithm)
     # This is the list of all known meta keys.
     # I do also an explicit check that all and only these are present
     # This is implicit since I will later also compare the exact dictionaries and not only their keys,
@@ -1533,17 +1433,13 @@ def test_stream_meta_single(temp_container, compress, compression_algorithm):
 
     content_packed = b'sffssdf383939'
     content_loose = b'v9fpaM'
-    hashkey_packed = temp_container.add_objects_to_pack(
-        [content_packed], compress=compress
-    )[0]
+    hashkey_packed = temp_container.add_objects_to_pack([content_packed], compress=compress)[0]
     hashkey_loose = temp_container.add_object(content_loose)
     hashkey_missing = 'unknown'
     compresser = utils.get_compressobj_instance(compression_algorithm)
     content_packed_compressed = compresser.compress(content_packed)
     content_packed_compressed += compresser.flush()
-    object_pack_length = (
-        len(content_packed) if not compress else len(content_packed_compressed)
-    )
+    object_pack_length = len(content_packed) if not compress else len(content_packed_compressed)
 
     expected_skip_missing_true = {
         hashkey_packed: {
@@ -1645,9 +1541,7 @@ def test_length_get_objects(temp_container):
     partial_hashkeys = list(data_dict)[:2]
     hashkeys = partial_hashkeys + partial_hashkeys + unknown_hashkeys + unknown_hashkeys
     iterated_hashkeys = []
-    with temp_container.get_objects_stream_and_meta(
-        hashkeys=hashkeys, skip_if_missing=False
-    ) as triplets:
+    with temp_container.get_objects_stream_and_meta(hashkeys=hashkeys, skip_if_missing=False) as triplets:
         for obj_hashkey, _, _ in triplets:
             iterated_hashkeys.append(obj_hashkey)
     # I should iterate on them ONLY ONCE
@@ -1659,9 +1553,7 @@ def test_length_get_objects(temp_container):
     partial_hashkeys = list(data_dict)[:2]
     hashkeys = partial_hashkeys + partial_hashkeys + unknown_hashkeys + unknown_hashkeys
     iterated_hashkeys = []
-    with temp_container.get_objects_stream_and_meta(
-        hashkeys=hashkeys, skip_if_missing=True
-    ) as triplets:
+    with temp_container.get_objects_stream_and_meta(hashkeys=hashkeys, skip_if_missing=True) as triplets:
         for obj_hashkey, _, _ in triplets:
             iterated_hashkeys.append(obj_hashkey)
     # I should iterate on them ONLY ONCE
@@ -1930,28 +1822,20 @@ def test_has_objects(temp_container):
     hashkey_pack1 = temp_container.add_object(b'1')
     hashkey_pack2 = temp_container.add_object(b'2')
     assert temp_container.has_objects([hashkey_pack1, hashkey_pack2]) == [True, True]
-    assert temp_container.has_objects(
-        [hashkey_pack2, unknown_hashkey, hashkey_pack1]
-    ) == [True, False, True]
+    assert temp_container.has_objects([hashkey_pack2, unknown_hashkey, hashkey_pack1]) == [True, False, True]
 
     # Verify that it still works after packing the object
     temp_container.pack_all_loose()
     assert temp_container.has_objects([hashkey_pack1, hashkey_pack2]) == [True, True]
-    assert temp_container.has_objects(
-        [hashkey_pack2, unknown_hashkey, hashkey_pack1]
-    ) == [True, False, True]
+    assert temp_container.has_objects([hashkey_pack2, unknown_hashkey, hashkey_pack1]) == [True, False, True]
 
     # Add a few more loose objects, and check that all works also with mixed loose and packed objects
     hashkey_loose1 = temp_container.add_object(b'3')
     hashkey_loose2 = temp_container.add_object(b'4')
     assert temp_container.has_objects([hashkey_pack1, hashkey_pack2]) == [True, True]
-    assert temp_container.has_objects(
-        [hashkey_pack2, unknown_hashkey, hashkey_pack1]
-    ) == [True, False, True]
+    assert temp_container.has_objects([hashkey_pack2, unknown_hashkey, hashkey_pack1]) == [True, False, True]
     assert temp_container.has_objects([hashkey_loose1, hashkey_loose2]) == [True, True]
-    assert temp_container.has_objects(
-        [hashkey_loose2, unknown_hashkey, hashkey_loose1]
-    ) == [True, False, True]
+    assert temp_container.has_objects([hashkey_loose2, unknown_hashkey, hashkey_loose1]) == [True, False, True]
     assert temp_container.has_objects(
         [hashkey_loose2, hashkey_pack1, unknown_hashkey, hashkey_loose1, hashkey_pack2]
     ) == [True, True, False, True, True]
@@ -2015,9 +1899,7 @@ def test_get_objects_meta_to_dict(temp_container):
     # Check tha the dict contains the right data
     assert all(meta['type'] == ObjectType.LOOSE for meta in meta_dict.values())
 
-    assert expected_sizes == {
-        hashkey: meta['size'] for hashkey, meta in meta_dict.items()
-    }
+    assert expected_sizes == {hashkey: meta['size'] for hashkey, meta in meta_dict.items()}
 
 
 @pytest.mark.parametrize('loose_prefix_len', [0, 2, 3])
@@ -2118,9 +2000,7 @@ def test_list_all_objects_extraneous(temp_dir, loose_prefix_len):  # pylint: dis
             pass
 
         # creating now a valid first_level folder (if not present already), and an invalid name inside it
-        first_level_subfolder = temp_container._get_loose_folder() / (
-            '0' * loose_prefix_len
-        )
+        first_level_subfolder = temp_container._get_loose_folder() / ('0' * loose_prefix_len)
         try:
             # Creating if it does not exist - this is a valid name
             os.mkdir(first_level_subfolder)
@@ -2164,9 +2044,7 @@ def test_import_to_pack(
         other_container.init_container(clear=True, hash_type=other_container_hash_type)
 
         hashkey1 = temp_container.add_object(obj1)
-        hashkey2, hashkey3 = temp_container.add_objects_to_pack(
-            [obj2, obj3], compress=compress_source
-        )
+        hashkey2, hashkey3 = temp_container.add_objects_to_pack([obj2, obj3], compress=compress_source)
 
         # Initial state
         assert temp_container.count_objects()['loose'] == 1
@@ -2297,9 +2175,7 @@ def test_validate_corrupt_packed(temp_container):
     assert issues.is_valid()
 
     # Corrupt the object
-    with open(
-        temp_container._get_pack_path_from_pack_id(str(meta['pack_id'])), 'wb'
-    ) as fhandle:
+    with open(temp_container._get_pack_path_from_pack_id(str(meta['pack_id'])), 'wb') as fhandle:
         fhandle.write(b'CORRU890890890809PT')
 
     # I don't use the dataclass .is_valid() method of ValidationIssues because I want to
@@ -2326,9 +2202,7 @@ def test_validate_overlapping_packed(temp_container):  # pylint: disable=invalid
     assert meta2['type'] == ObjectType.PACKED
 
     # Hashkey of the object stored later in the pack
-    hashkey_second = (
-        hashkey2 if meta1['pack_offset'] < meta2['pack_offset'] else hashkey1
-    )
+    hashkey_second = hashkey2 if meta1['pack_offset'] < meta2['pack_offset'] else hashkey1
 
     # No errors yet
     temp_container.validate()
@@ -2336,9 +2210,9 @@ def test_validate_overlapping_packed(temp_container):  # pylint: disable=invalid
     assert issues.is_valid()
 
     # Change the offset of the second object so that it's overlapping
-    temp_container._get_operation_session().query(database.Obj).filter(
-        database.Obj.hashkey == hashkey_second
-    ).update({database.Obj.offset: database.Obj.offset - 1})
+    temp_container._get_operation_session().query(database.Obj).filter(database.Obj.hashkey == hashkey_second).update(
+        {database.Obj.offset: database.Obj.offset - 1}
+    )
 
     errors = dataclasses.asdict(temp_container.validate())
     problems = errors.pop('overlapping_packed')
@@ -2362,9 +2236,7 @@ def test_validate_corrupt_packed_size(temp_container):  # pylint: disable=invali
     assert issues.is_valid()
 
     # Corrupt the object
-    with open(
-        temp_container._get_pack_path_from_pack_id(str(meta['pack_id'])), 'wb'
-    ) as fhandle:
+    with open(temp_container._get_pack_path_from_pack_id(str(meta['pack_id'])), 'wb') as fhandle:
         # Short corrupted string so also the size is wrong
         fhandle.write(b'COR')
 
@@ -2405,8 +2277,7 @@ def test_validate_callback(temp_container, callback_instance):
 
     # I convert to dict because I the order of the actions can change
     performed_actions_dict = {
-        action['start_value']['description']: action
-        for action in callback_instance.performed_actions
+        action['start_value']['description']: action for action in callback_instance.performed_actions
     }
 
     assert performed_actions_dict == {
@@ -2435,9 +2306,7 @@ def test_add_streamed_object_to_pack_callback(  # pylint: disable=invalid-name
             stream, callback_size_hint=length, callback=callback_instance.callback
         )
     else:
-        hashkey = temp_container.add_streamed_object_to_pack(
-            stream, callback=callback_instance.callback
-        )
+        hashkey = temp_container.add_streamed_object_to_pack(stream, callback=callback_instance.callback)
 
     assert temp_container.get_object_content(hashkey) == content
 
@@ -2456,9 +2325,7 @@ def test_add_streamed_object_to_pack_callback(  # pylint: disable=invalid-name
     ]
 
 
-@pytest.mark.parametrize(
-    'no_holes,no_holes_read_twice', [[True, True], [True, False], [False, False]]
-)
+@pytest.mark.parametrize('no_holes,no_holes_read_twice', [[True, True], [True, False], [False, False]])
 def test_add_streamed_objects_to_pack_callback(  # pylint: disable=invalid-name
     temp_container, callback_instance, no_holes, no_holes_read_twice
 ):
@@ -2518,9 +2385,7 @@ def test_add_streamed_objects_to_pack_callback(  # pylint: disable=invalid-name
 
 # Check both with the same hash type and with a different one
 @pytest.mark.parametrize('other_container_hash_type', ['sha256', 'sha1'])
-def test_import_objects_callback(
-    temp_container, callback_instance, other_container_hash_type
-):
+def test_import_objects_callback(temp_container, callback_instance, other_container_hash_type):
     """Test the correctness of the callback of import_objects."""
     # Add packed objects (2001, 10 chars each)
     len_packed = 2001
@@ -2533,18 +2398,10 @@ def test_import_objects_callback(
         other_container.init_container(clear=True, hash_type=other_container_hash_type)
 
         # Import objects
-        other_container.import_objects(
-            hashkeys, temp_container, callback=callback_instance.callback
-        )
+        other_container.import_objects(hashkeys, temp_container, callback=callback_instance.callback)
 
-        assert (
-            other_container.count_objects()['loose']
-            == temp_container.count_objects()['loose']
-        )
-        assert (
-            other_container.count_objects()['packed']
-            == temp_container.count_objects()['packed']
-        )
+        assert other_container.count_objects()['loose'] == temp_container.count_objects()['loose']
+        assert other_container.count_objects()['packed'] == temp_container.count_objects()['packed']
 
         # close before exiting the context manager, so files are closed.
         other_container.close()
@@ -2583,9 +2440,7 @@ def test_delete(temp_container, compress, ask_deleting_unknown):  # pylint: disa
     obj2 = b'jklf2wv'  # Will be loose
     obj3 = b'9z0vx0'  # Will be stored directly packed
 
-    unknown_hashkey = utils.get_hash_cls(temp_container.hash_type)(
-        b'NOT_EXISTING_OBJECT_CONTENT'
-    ).hexdigest()
+    unknown_hashkey = utils.get_hash_cls(temp_container.hash_type)(b'NOT_EXISTING_OBJECT_CONTENT').hexdigest()
 
     hashkey1 = temp_container.add_object(obj1)
     temp_container.pack_all_loose(compress=compress)
@@ -2927,10 +2782,11 @@ def test_clean_storage_with_duplicates(
     assert set(temp_container.list_all_objects()) == {hashkey1, hashkey2, hashkey3}
 
     # All contents have been restored, and no mistake has been done by replacing the content of wrong objects
-    assert {
-        hashkey: temp_container.get_object_content(hashkey)
-        for hashkey in [hashkey1, hashkey2, hashkey3]
-    } == {hashkey1: content1, hashkey2: content2, hashkey3: content3}
+    assert {hashkey: temp_container.get_object_content(hashkey) for hashkey in [hashkey1, hashkey2, hashkey3]} == {
+        hashkey1: content1,
+        hashkey2: content2,
+        hashkey3: content3,
+    }
 
 
 def test_clean_storage_with_duplicates_all_corrupt(
@@ -3070,14 +2926,10 @@ def test_clean_storage_with_duplicates_original_deleted(
     assert not list(temp_container.list_all_objects())
 
 
-@pytest.mark.parametrize(
-    'no_holes, no_holes_read_twice', [[True, True], [True, False], [False, True]]
-)
+@pytest.mark.parametrize('no_holes, no_holes_read_twice', [[True, True], [True, False], [False, True]])
 @pytest.mark.parametrize('use_streams', [True, False])
 @pytest.mark.parametrize('compress', [True, False])
-def test_packs_no_holes(
-    temp_container, no_holes, no_holes_read_twice, use_streams, compress, monkeypatch
-):
+def test_packs_no_holes(temp_container, no_holes, no_holes_read_twice, use_streams, compress, monkeypatch):
     """Test what happens when writing directly to packs and asking not to leave back holes."""
     content1 = b'1234567'
     content2 = b'wefvmafsf'
@@ -3115,16 +2967,11 @@ def test_packs_no_holes(
     assert sizes['total_size_packed'] == len(content1) + len(content2) + len(content3)
 
     if no_holes:
-        assert (
-            sizes['total_size_packed_on_disk'] == sizes['total_size_packfiles_on_disk']
-        )
+        assert sizes['total_size_packed_on_disk'] == sizes['total_size_packfiles_on_disk']
     else:
         # We have added twice each object. Note: we cannot use total_size_packed because this would be
         # before compression
-        assert (
-            2 * sizes['total_size_packed_on_disk']
-            == sizes['total_size_packfiles_on_disk']
-        )
+        assert 2 * sizes['total_size_packed_on_disk'] == sizes['total_size_packfiles_on_disk']
 
     # Add again the same objects, in a new call
     # I first monkeypatch the method `_write_data_to_packfile`. This writes to disk, and should never be called
@@ -3145,9 +2992,7 @@ def test_packs_no_holes(
     monkeypatch.setattr(
         temp_container,
         '_write_data_to_packfile',
-        functools.partial(
-            new_write_data_to_packfile, self=temp_container, call_counter=call_counter
-        ),
+        functools.partial(new_write_data_to_packfile, self=temp_container, call_counter=call_counter),
     )
 
     if use_streams:
@@ -3178,29 +3023,17 @@ def test_packs_no_holes(
 
     new_sizes = temp_container.get_total_size()
     # No new objects, so same size
-    assert new_sizes['total_size_packed'] == len(content1) + len(content2) + len(
-        content3
-    )
+    assert new_sizes['total_size_packed'] == len(content1) + len(content2) + len(content3)
 
     if no_holes:
         # Shouldn't have created more space on disk
-        assert (
-            new_sizes['total_size_packed_on_disk'] == sizes['total_size_packed_on_disk']
-        )
-        assert (
-            new_sizes['total_size_packfiles_on_disk']
-            == sizes['total_size_packfiles_on_disk']
-        )
+        assert new_sizes['total_size_packed_on_disk'] == sizes['total_size_packed_on_disk']
+        assert new_sizes['total_size_packfiles_on_disk'] == sizes['total_size_packfiles_on_disk']
     else:
         # We have doubled the space on disk
-        assert (
-            new_sizes['total_size_packfiles_on_disk']
-            == 2 * sizes['total_size_packfiles_on_disk']
-        )
+        assert new_sizes['total_size_packfiles_on_disk'] == 2 * sizes['total_size_packfiles_on_disk']
         # (but shouldn't have increased the size of packed objects on disk)
-        assert (
-            new_sizes['total_size_packed_on_disk'] == sizes['total_size_packed_on_disk']
-        )
+        assert new_sizes['total_size_packed_on_disk'] == sizes['total_size_packed_on_disk']
 
 
 def test_packs_read_in_order(temp_dir):
@@ -3238,9 +3071,7 @@ def test_packs_read_in_order(temp_dir):
     last_pack = None
     seen_packs = set()
 
-    with temp_container.get_objects_stream_and_meta(
-        hashkeys, skip_if_missing=False
-    ) as triplets:
+    with temp_container.get_objects_stream_and_meta(hashkeys, skip_if_missing=False) as triplets:
         for _, _, meta in triplets:  # pylint: disable=not-an-iterable
             assert meta['type'] == ObjectType.PACKED
             if last_pack is None:
@@ -3361,13 +3192,9 @@ def test_repack(temp_dir, compress_mode):
     assert size['total_size_packed'] == 10 * (len(data) - len(to_delete))
     # This time also the size on disk should be adapted (it's the main goal of repacking)
     objects_meta = dict(
-        temp_container.get_objects_meta(
-            [hashkeys[idx] for idx in range(len(hashkeys)) if idx not in idx_to_delete]
-        )
+        temp_container.get_objects_meta([hashkeys[idx] for idx in range(len(hashkeys)) if idx not in idx_to_delete])
     )
-    assert size['total_size_packfiles_on_disk'] == sum(
-        list(meta['pack_length'] for meta in objects_meta.values())
-    )
+    assert size['total_size_packfiles_on_disk'] == sum(list(meta['pack_length'] for meta in objects_meta.values()))
 
     # Check that the content is still correct
     # Should not raise
@@ -3381,9 +3208,7 @@ def test_repack(temp_dir, compress_mode):
 @pytest.mark.parametrize('repack_compress_mode', list(CompressMode))
 @pytest.mark.parametrize('compress_pack', [True, False])
 @pytest.mark.parametrize('small_size', [True, False])
-def test_repack_compress_modes(
-    temp_container: Container, small_size, compress_pack, repack_compress_mode
-):
+def test_repack_compress_modes(temp_container: Container, small_size, compress_pack, repack_compress_mode):
     """Check that repack() uses the correct compression mode."""
 
     # Write 10*1_000_000 = 10 million bytes, larger than a chunk
@@ -3402,14 +3227,8 @@ def test_repack_compress_modes(
 
     temp_container.pack_all_loose(compress=compress_pack)
     # Both should have the expected compression mode from the variable `compress_mode`
-    assert (
-        temp_container.get_object_meta(hashkey_compr)['pack_compressed']
-        == compress_pack
-    )
-    assert (
-        temp_container.get_object_meta(hashkey_uncompr)['pack_compressed']
-        == compress_pack
-    )
+    assert temp_container.get_object_meta(hashkey_compr)['pack_compressed'] == compress_pack
+    assert temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] == compress_pack
 
     # We now repack, and check if everything is correct
     temp_container.repack(compress_mode=repack_compress_mode)
@@ -3422,31 +3241,19 @@ def test_repack_compress_modes(
     if repack_compress_mode == CompressMode.NO:
         # All should be uncompressed
         assert temp_container.get_object_meta(hashkey_compr)['pack_compressed'] is False
-        assert (
-            temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is False
-        )
+        assert temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is False
     elif repack_compress_mode == CompressMode.YES:
         # All should be compressed
         assert temp_container.get_object_meta(hashkey_compr)['pack_compressed'] is True
-        assert (
-            temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is True
-        )
+        assert temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is True
     elif repack_compress_mode == CompressMode.KEEP:
         # Should not have changed
-        assert (
-            temp_container.get_object_meta(hashkey_compr)['pack_compressed']
-            == compress_pack
-        )
-        assert (
-            temp_container.get_object_meta(hashkey_uncompr)['pack_compressed']
-            == compress_pack
-        )
+        assert temp_container.get_object_meta(hashkey_compr)['pack_compressed'] == compress_pack
+        assert temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] == compress_pack
     elif repack_compress_mode == CompressMode.AUTO:
         # Only really compressible streams should be compressed
         assert temp_container.get_object_meta(hashkey_compr)['pack_compressed'] is True
-        assert (
-            temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is False
-        )
+        assert temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is False
     else:
         raise AssertionError(
             f'Unknown {repack_compress_mode=}, most probably you added a new CompressMode and need to update the tests'
@@ -3501,9 +3308,7 @@ def test_repack_progress_bar(temp_container: Container):
     def progress(action, value):
         """A dummy progress function."""
         if action == 'init':
-            assert (
-                value['total'] == temp_container.get_total_size()['total_size_packed']
-            )
+            assert value['total'] == temp_container.get_total_size()['total_size_packed']
             nonlocal passed_total
             passed_total = value['total']
             assert value['description'] == 'Repack 0'
@@ -3542,27 +3347,19 @@ def test_pack_all_loose_compress_modes(temp_container: Container, compress_mode)
     if compress_mode == CompressMode.NO or compress_mode is False:
         # All should be uncompressed
         assert temp_container.get_object_meta(hashkey_compr)['pack_compressed'] is False
-        assert (
-            temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is False
-        )
+        assert temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is False
     elif compress_mode == CompressMode.YES or compress_mode is True:
         # All should be compressed
         assert temp_container.get_object_meta(hashkey_compr)['pack_compressed'] is True
-        assert (
-            temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is True
-        )
+        assert temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is True
     elif compress_mode == CompressMode.KEEP:
         # Should not have changed - so it should be False since loose objects are always uncompressed
         assert temp_container.get_object_meta(hashkey_compr)['pack_compressed'] is False
-        assert (
-            temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is False
-        )
+        assert temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is False
     elif compress_mode == CompressMode.AUTO:
         # Only really compressible streams should be compressed
         assert temp_container.get_object_meta(hashkey_compr)['pack_compressed'] is True
-        assert (
-            temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is False
-        )
+        assert temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is False
     else:
         raise AssertionError(
             f'Unknown {compress_mode=}, most probably you added a new CompressMode and need to update the tests'
@@ -3641,9 +3438,7 @@ def test_container_id(temp_container):
 def test_unknown_compressers(temp_container, compression_algorithm):
     """Check that unknown or invalid compressers give a ValueError."""
     with pytest.raises(ValueError):
-        temp_container.init_container(
-            clear=True, compression_algorithm=compression_algorithm
-        )
+        temp_container.init_container(clear=True, compression_algorithm=compression_algorithm)
 
 
 ## I add tests for the LazyLooseStream here - even if it's in the `utils`,
@@ -3785,9 +3580,7 @@ def test_lazy_loose_stream_context_man(temp_container):
 
 
 @pytest.mark.parametrize('num_iterations_delete', [3, 10])
-def test_lazy_loose_loosen_and_delete(
-    temp_container, num_iterations_delete, monkeypatch
-):
+def test_lazy_loose_loosen_and_delete(temp_container, num_iterations_delete, monkeypatch):
     """
     Test what happens if a loose file is deleted right after it's loosened.
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,4 +1,5 @@
 """Test of the object-store container module."""
+
 # pylint: disable=too-many-lines,protected-access
 import dataclasses
 import functools
@@ -19,18 +20,18 @@ import disk_objectstore.exceptions as exc
 from disk_objectstore import CompressMode, Container, ObjectType, database, utils
 from disk_objectstore.dataclasses import ObjectMeta
 
-COMPRESSION_ALGORITHMS_TO_TEST = ["zlib+1", "zlib+9"]
+COMPRESSION_ALGORITHMS_TO_TEST = ['zlib+1', 'zlib+9']
 
 
 class UnopenableBytesIO(io.BytesIO):
     """An extension of BytesIO that cannot be used as a context manager."""
 
     def __enter__(self):
-        raise AttributeError("__enter__ method disabled for UnopenableBytesIO")
+        raise AttributeError('__enter__ method disabled for UnopenableBytesIO')
 
     @property
     def mode(self):
-        return "rb"
+        return 'rb'
 
 
 def _assert_empty_repo(container):
@@ -40,13 +41,13 @@ def _assert_empty_repo(container):
     """
     counts = container.count_objects()
     assert (
-        counts["packed"] == 0
+        counts['packed'] == 0
     ), f"The container should be empty at the beginning (but there are {counts['packed']} packed objects)"
     assert (
-        counts["loose"] == 0
+        counts['loose'] == 0
     ), f"The container should be empty at the beginning (but there are {counts['loose']} loose objects)"
     assert (
-        counts["pack_files"] == 0
+        counts['pack_files'] == 0
     ), f"The container should be empty at the beginning (but there are {counts['pack_files']} pack files)"
 
 
@@ -111,7 +112,7 @@ def _get_data_and_md5_bulk(container, obj_hashkeys):
     return retval
 
 
-@pytest.mark.parametrize("retrieve_bulk", [True, False])
+@pytest.mark.parametrize('retrieve_bulk', [True, False])
 def test_add_get_loose(temp_container, generate_random_data, retrieve_bulk):
     """Add a number of objects (one by one, loose) to the container.
 
@@ -125,11 +126,11 @@ def test_add_get_loose(temp_container, generate_random_data, retrieve_bulk):
 
     counts = temp_container.count_objects()
     assert (
-        counts["packed"] == 0
+        counts['packed'] == 0
     ), f"The container should have no packed objects (but there are {counts['packed']} instead)"
     # I check with the length of the set because I could have picked to random identical objects
-    assert counts["loose"] == len(
-        set(obj_md5s)
+    assert (
+        counts['loose'] == len(set(obj_md5s))
     ), f"The container should have {len(set(obj_md5s))} loose objects (but there are {counts['loose']} instead)"
 
     # Retrieve objects (loose), in random order
@@ -154,12 +155,12 @@ def test_add_get_loose(temp_container, generate_random_data, retrieve_bulk):
 def test_add_loose_from_stream(temp_container):
     """Test adding an object from a stream (from an open file, for instance)."""
     # Write 10*100000 = 1 million bytes, larger than a chunk
-    content = b"0123456789" * 1000000
+    content = b'0123456789' * 1000000
 
-    with tempfile.NamedTemporaryFile(mode="wb", delete=False) as temp_handle:
+    with tempfile.NamedTemporaryFile(mode='wb', delete=False) as temp_handle:
         temp_handle.write(content)
 
-    with open(temp_handle.name, "rb") as read_handle:
+    with open(temp_handle.name, 'rb') as read_handle:
         hashkey = temp_container.add_streamed_object(read_handle)
 
     read_content = temp_container.get_object_content(hashkey)
@@ -170,7 +171,7 @@ def test_add_loose_from_stream(temp_container):
 
 
 @pytest.mark.parametrize(
-    "use_compression,retrieve_bulk",
+    'use_compression,retrieve_bulk',
     [(True, True), (True, False), (False, True), (False, False)],
 )
 def test_add_get_with_packing(
@@ -190,11 +191,11 @@ def test_add_get_with_packing(
     temp_container.pack_all_loose(compress=use_compression)
 
     counts = temp_container.count_objects()
-    assert counts["packed"] == len(
-        set(obj_md5s)
+    assert (
+        counts['packed'] == len(set(obj_md5s))
     ), f"The container should have {len(set(obj_md5s))} packed objects (but there are {counts['packed']} instead)"
     # Loose objects are not immediately deleted
-    assert counts["loose"] == len(set(obj_md5s)), (
+    assert counts['loose'] == len(set(obj_md5s)), (
         f"The container should still have all {len(set(obj_md5s))} loose objects "
         f"(but there are {counts['loose']} instead)"
     )
@@ -204,7 +205,7 @@ def test_add_get_with_packing(
     counts = temp_container.count_objects()
     # Now there shouldn't be any more loose objects
     assert (
-        counts["loose"] == 0
+        counts['loose'] == 0
     ), f"The container should have 0 loose objects (but there are {counts['loose']} instead)"
 
     # Retrieve objects (loose), in random order
@@ -226,7 +227,7 @@ def test_add_get_with_packing(
         ), f"Object '{obj_hashkey}' has wrong MD5s ({obj_md5s[obj_hashkey]} vs {retrieved_md5s[obj_hashkey]})"
 
 
-@pytest.mark.parametrize("use_compression", [True, False])
+@pytest.mark.parametrize('use_compression', [True, False])
 def test_directly_to_pack_content(
     temp_container, generate_random_data, use_compression
 ):
@@ -243,11 +244,11 @@ def test_directly_to_pack_content(
     )
 
     counts = temp_container.count_objects()
-    assert counts["packed"] == len(
-        set(data)
+    assert (
+        counts['packed'] == len(set(data))
     ), f"The container should have {len(set(data))} packed objects (but there are {counts['packed']} instead)"
     assert (
-        counts["loose"] == 0
+        counts['loose'] == 0
     ), f"The container should have 0 loose objects (but there are {counts['loose']} instead)"
 
     # Retrieve objects (loose), in random order
@@ -267,7 +268,7 @@ def test_directly_to_pack_content(
 
 
 @pytest.mark.parametrize(
-    "use_compression,use_packing,clean_storage",
+    'use_compression,use_packing,clean_storage',
     [
         (True, True, True),
         (True, True, False),
@@ -277,7 +278,7 @@ def test_directly_to_pack_content(
 )
 def test_stream_seek(temp_container, use_compression, use_packing, clean_storage):
     """Test that stream returned by `Container.get_object_stream` is properly seekable."""
-    content = b"0123456789abcdef"
+    content = b'0123456789abcdef'
     hashkey = temp_container.add_object(content)
 
     if use_packing:
@@ -358,12 +359,12 @@ def test_container_context_manager(temp_dir):
     """
     with Container(folder=temp_dir) as container:
         container.init_container(clear=True)
-        container.add_object(b"abc")
+        container.add_object(b'abc')
         container.pack_all_loose()
-        assert container._operation_session is not None, "Session should be open"
+        assert container._operation_session is not None, 'Session should be open'
     assert (
         container._operation_session is None
-    ), "Session should be closed when going out of the context manager"
+    ), 'Session should be closed when going out of the context manager'
 
 
 def test_num_packs_with_target_size(temp_dir, generate_random_data):
@@ -390,15 +391,15 @@ def test_num_packs_with_target_size(temp_dir, generate_random_data):
     temp_container.init_container(clear=True, pack_size_target=pack_size_target)
 
     counts = temp_container.count_objects()
-    assert counts["pack_files"] == 0
+    assert counts['pack_files'] == 0
 
     hashkeys += temp_container.add_objects_to_pack(data, compress=False)
     object_data += data
 
     # Check that enough packs were created
     counts = temp_container.count_objects()
-    assert counts["pack_files"] >= min_expected_num_packs
-    current_num_packfiles = counts["pack_files"]
+    assert counts['pack_files'] >= min_expected_num_packs
+    current_num_packfiles = counts['pack_files']
 
     # Create a new object of 2*the pack_size_target, as a 'template'.
     # Because of the length, they are surely different from previous data
@@ -409,9 +410,9 @@ def test_num_packs_with_target_size(temp_dir, generate_random_data):
         ).values()
     )[0]
     # Create three objects from this template, with different suffix, so hash key is different
-    new_obj1 = new_obj + b"1"
-    new_obj2 = new_obj + b"2"
-    new_obj3 = new_obj + b"3"
+    new_obj1 = new_obj + b'1'
+    new_obj2 = new_obj + b'2'
+    new_obj3 = new_obj + b'3'
     # Put the first two objects
     hashkeys += temp_container.add_objects_to_pack([new_obj1, new_obj2], compress=False)
     object_data += [new_obj1, new_obj2]
@@ -419,17 +420,17 @@ def test_num_packs_with_target_size(temp_dir, generate_random_data):
     # Check that at least one new pack has been created (probably the first one might have ended
     # up in the previous incomplete pack, but the second one must go definitely in a new pack)
     counts = temp_container.count_objects()
-    assert counts["pack_files"] >= current_num_packfiles + 1
+    assert counts['pack_files'] >= current_num_packfiles + 1
 
     # Update the current number of pack files
-    current_num_packfiles = counts["pack_files"]
+    current_num_packfiles = counts['pack_files']
 
     # Adding a new object must create a new pack, since the previous one is for sure full (it contains
     # only one object, whose size is larger than the pack_size_target)
     hashkeys += temp_container.add_objects_to_pack([new_obj3], compress=False)
     object_data += [new_obj3]
     counts = temp_container.count_objects()
-    assert counts["pack_files"] == current_num_packfiles + 1
+    assert counts['pack_files'] == current_num_packfiles + 1
 
     # Read all objects, and check content.
     # This also triggers all the logic to close open files, with more than one pack.
@@ -441,9 +442,9 @@ def test_num_packs_with_target_size(temp_dir, generate_random_data):
 
 
 # Try a large and a small one
-@pytest.mark.parametrize("pack_size_target", [1000, 40000000])
+@pytest.mark.parametrize('pack_size_target', [1000, 40000000])
 @pytest.mark.parametrize(
-    "use_compression,open_streams",
+    'use_compression,open_streams',
     [(True, True), (True, False), (False, True), (False, False)],
 )
 def test_directly_to_pack_streamed(
@@ -469,7 +470,7 @@ def test_directly_to_pack_streamed(
             # Read a given fixed order, otherwise later when reconstructing obj_md5s we would have a problem
             for key, content in zip(keys, values):
                 file_path = Path(temp_dir2) / key
-                with open(file_path, "bw") as fhandle:
+                with open(file_path, 'bw') as fhandle:
                     fhandle.write(content)
                 streams.append(utils.LazyOpener(file_path))
                 streams_copy.append(utils.LazyOpener(file_path))
@@ -500,11 +501,11 @@ def test_directly_to_pack_streamed(
     obj_md5s = dict(zip(obj_hashkeys, keys))
 
     counts = temp_container.count_objects()
-    assert counts["packed"] == len(
-        set(data)
+    assert (
+        counts['packed'] == len(set(data))
     ), f"The container should have {len(set(data))} packed objects (but there are {counts['packed']} instead)"
     assert (
-        counts["loose"] == 0
+        counts['loose'] == 0
     ), f"The container should have 0 loose objects (but there are {counts['loose']} instead)"
 
     # Retrieve objects (loose), in random order
@@ -527,7 +528,7 @@ def test_directly_to_pack_streamed(
 
 
 @pytest.mark.parametrize(
-    "loose_prefix_len,pack_size_target",
+    'loose_prefix_len,pack_size_target',
     [(0, 1000), (2, 1000), (3, 1000), (0, 40000000), (2, 40000000), (3, 40000000)],
 )
 def test_prefix_lengths(
@@ -563,10 +564,10 @@ def test_prefix_lengths(
 
     counts = container.count_objects()
     assert (
-        counts["packed"] == 0
+        counts['packed'] == 0
     ), f"The container should have 0 packed objects (but there are {counts['packed']} instead)"
-    assert counts["loose"] == len(
-        set(obj_md5s)
+    assert (
+        counts['loose'] == len(set(obj_md5s))
     ), f"The container should have {len(set(obj_md5s))} loose objects (but there are {counts['loose']} instead)"
 
     retrieved_md5s = _get_data_and_md5_bulk(container, obj_md5s.keys())
@@ -589,11 +590,11 @@ def test_prefix_lengths(
     )
 
     counts = container.count_objects()
-    assert counts["packed"] == len(
-        set(obj_md5s)
+    assert (
+        counts['packed'] == len(set(obj_md5s))
     ), f"The container should have {len(set(obj_md5s))} packed objects (but there are {counts['packed']} instead)"
     # Loose objects are not immediately deleted
-    assert counts["loose"] == len(set(obj_md5s)), (
+    assert counts['loose'] == len(set(obj_md5s)), (
         f"The container should still have all {len(set(obj_md5s))} loose objects "
         f"(but there are {counts['loose']} instead)"
     )
@@ -603,7 +604,7 @@ def test_prefix_lengths(
     counts = container.count_objects()
     # Now there shouldn't be any more loose objects
     assert (
-        counts["loose"] == 0
+        counts['loose'] == 0
     ), f"The container should have 0 loose objects (but there are {counts['loose']} instead)"
 
     retrieved_md5s = _get_data_and_md5_bulk(container, obj_md5s.keys())
@@ -614,13 +615,13 @@ def test_prefix_lengths(
         ), f"Object '{obj_hashkey}' has wrong MD5s ({obj_md5s[obj_hashkey]} vs {retrieved_md5s[obj_hashkey]})"
 
     # Test also the validation functions
-    valid_pack_ids = ["0", "1", "2", "10", "100"]
-    invalid_pack_ids = ["", "01", "0a", "1-"]
-    valid_loose_prefixes = ["0" * loose_prefix_len, "a" * loose_prefix_len]
+    valid_pack_ids = ['0', '1', '2', '10', '100']
+    invalid_pack_ids = ['', '01', '0a', '1-']
+    valid_loose_prefixes = ['0' * loose_prefix_len, 'a' * loose_prefix_len]
     invalid_loose_prefixes = [
-        "0" * (loose_prefix_len + 1),
-        "a" * (loose_prefix_len + 1),
-        "g" * loose_prefix_len if loose_prefix_len else "g",
+        '0' * (loose_prefix_len + 1),
+        'a' * (loose_prefix_len + 1),
+        'g' * loose_prefix_len if loose_prefix_len else 'g',
     ]
 
     for pack_id in valid_pack_ids:
@@ -642,7 +643,7 @@ def test_prefix_lengths(
     container.close()
 
 
-@pytest.mark.parametrize("pack_size_target", [-1, -2])
+@pytest.mark.parametrize('pack_size_target', [-1, -2])
 def test_invalid_pack_size_target(temp_dir, pack_size_target):
     """Check that the prefix lengths and the size targets."""
     container = Container(temp_dir)
@@ -650,7 +651,7 @@ def test_invalid_pack_size_target(temp_dir, pack_size_target):
         container.init_container(clear=True, pack_size_target=pack_size_target)
 
 
-@pytest.mark.parametrize("loose_prefix_len", [-1, -2])
+@pytest.mark.parametrize('loose_prefix_len', [-1, -2])
 def test_invalid_prefix_length(temp_dir, loose_prefix_len):
     """Check that the prefix lengths and the size targets."""
     container = Container(temp_dir)
@@ -662,7 +663,7 @@ def test_invalid_hash_type(temp_dir):
     """Check that the prefix lengths and the size targets."""
     container = Container(temp_dir)
     with pytest.raises(ValueError):
-        container.init_container(clear=True, hash_type="unknown-type")
+        container.init_container(clear=True, hash_type='unknown-type')
 
 
 def test_initialisation(temp_dir):
@@ -690,10 +691,10 @@ def test_initialisation(temp_dir):
 
     with pytest.raises(FileExistsError) as excinfo:
         container.init_container()
-    assert "already exists" in str(excinfo.value)
+    assert 'already exists' in str(excinfo.value)
 
     # I artificially remove one of the folders: it should notice and say it's not initialised
-    os.rmdir(container.get_folder() / "sandbox")
+    os.rmdir(container.get_folder() / 'sandbox')
     assert not container.is_initialised
 
     # Close open files (the DB)
@@ -708,16 +709,16 @@ def test_initialisation(temp_dir):
     assert not container.is_initialised
 
     # Create an empty file
-    with open(container.get_folder() / "somefile", "w"):
+    with open(container.get_folder() / 'somefile', 'w'):
         pass
     # Final re-initialisation
     with pytest.raises(FileExistsError) as excinfo:
         container.init_container()
-    assert "already some file or folder" in str(excinfo.value)
+    assert 'already some file or folder' in str(excinfo.value)
 
 
-@pytest.mark.parametrize("hash_type", ["sha256", "sha1"])
-@pytest.mark.parametrize("compress", [True, False])
+@pytest.mark.parametrize('hash_type', ['sha256', 'sha1'])
+@pytest.mark.parametrize('compress', [True, False])
 def test_check_hash_computation(temp_dir, hash_type, compress):
     """Check that the hashes are correctly computed, when storing loose,
     directly to packs, and while repacking all loose.
@@ -727,9 +728,9 @@ def test_check_hash_computation(temp_dir, hash_type, compress):
     # Re-init the container with the correct hash type
     container = Container(temp_dir)
     container.init_container(hash_type=hash_type, clear=True)
-    content1 = b"1"
-    content2 = b"222"
-    content3 = b"n2fwd"
+    content1 = b'1'
+    content2 = b'222'
+    content3 = b'n2fwd'
 
     expected_hasher = getattr(hashlib, hash_type)
 
@@ -746,15 +747,15 @@ def test_check_hash_computation(temp_dir, hash_type, compress):
     container.pack_all_loose(compress=compress, validate_objects=True)
 
 
-@pytest.mark.parametrize("validate_objects", [True, False])
-@pytest.mark.parametrize("corrupt", [True, False])
-@pytest.mark.parametrize("compress", [True, False])
+@pytest.mark.parametrize('validate_objects', [True, False])
+@pytest.mark.parametrize('corrupt', [True, False])
+@pytest.mark.parametrize('compress', [True, False])
 def test_validation_while_packing(temp_container, compress, corrupt, validate_objects):
     """Check that, if while packing loose objects, the validation (when asked for) works."""
-    content1 = b"34gq34"
-    content2 = b"jsdklvjvldk"
+    content1 = b'34gq34'
+    content2 = b'jsdklvjvldk'
 
-    corrupted_content2 = b"CORRUPTED"
+    corrupted_content2 = b'CORRUPTED'
 
     hashkey1 = temp_container.add_object(content1)
     hashkey2 = temp_container.add_object(content2)
@@ -762,7 +763,7 @@ def test_validation_while_packing(temp_container, compress, corrupt, validate_ob
     # Corrupt the content of a loose object
     if corrupt:
         with open(
-            temp_container._get_loose_path_from_hashkey(hashkey2), "wb"
+            temp_container._get_loose_path_from_hashkey(hashkey2), 'wb'
         ) as fhandle:
             fhandle.write(corrupted_content2)
 
@@ -772,14 +773,14 @@ def test_validation_while_packing(temp_container, compress, corrupt, validate_ob
                 compress=compress, validate_objects=validate_objects
             )
         # hashkey2 should have been left as 'loose'. Hashkey1 could be either packed or loose, so we don't check.
-        assert temp_container.get_object_meta(hashkey2)["type"] == ObjectType.LOOSE
+        assert temp_container.get_object_meta(hashkey2)['type'] == ObjectType.LOOSE
     else:
         temp_container.pack_all_loose(
             compress=compress, validate_objects=validate_objects
         )
         # Both should have been packed
-        assert temp_container.get_object_meta(hashkey1)["type"] == ObjectType.PACKED
-        assert temp_container.get_object_meta(hashkey2)["type"] == ObjectType.PACKED
+        assert temp_container.get_object_meta(hashkey1)['type'] == ObjectType.PACKED
+        assert temp_container.get_object_meta(hashkey2)['type'] == ObjectType.PACKED
 
     # Check content
     assert temp_container.get_object_content(hashkey1) == content1
@@ -792,7 +793,7 @@ def test_validation_while_packing(temp_container, compress, corrupt, validate_ob
 
 # Only three options: if pack_objects is False, the values of compress_packs is ignored
 @pytest.mark.parametrize(
-    "pack_objects,compress_packs", [(True, True), (True, False), (False, False)]
+    'pack_objects,compress_packs', [(True, True), (True, False), (False, False)]
 )
 def test_unknown_hashkeys(
     temp_container, generate_random_data, pack_objects, compress_packs
@@ -811,7 +812,7 @@ def test_unknown_hashkeys(
     # 2 unknown keys, one even with invalid format
     # I don't use a 'real' SHA checksum as it could be randomly picked by the
     # randomly generated data
-    unknown_hashkeys = ["281ab9a49afbf4c8996fb92427ae41e4649"] + ["invalid--string"]
+    unknown_hashkeys = ['281ab9a49afbf4c8996fb92427ae41e4649'] + ['invalid--string']
 
     # Loop read
     for unknown_hashkey in unknown_hashkeys:
@@ -846,11 +847,11 @@ def test_unknown_hashkeys(
     ) as triplets:
         for obj_hashkey, stream, meta in triplets:
             if stream is None:
-                assert meta["size"] is None
+                assert meta['size'] is None
                 missing.append(obj_hashkey)
             else:
                 check_md5s[obj_hashkey] = stream.read()
-                assert len(check_md5s[obj_hashkey]) == meta["size"]
+                assert len(check_md5s[obj_hashkey]) == meta['size']
     # The retrieved values should be only the valid ones
     assert not missing  # check that the list is empty
     check_md5s = {key: hashlib.md5(val).hexdigest() for key, val in contents.items()}
@@ -875,11 +876,11 @@ def test_unknown_hashkeys(
     ) as triplets:
         for obj_hashkey, stream, meta in triplets:
             if stream is None:
-                assert meta["size"] is None
+                assert meta['size'] is None
                 missing.append(obj_hashkey)
             else:
                 check_md5s[obj_hashkey] = stream.read()
-                assert len(check_md5s[obj_hashkey]) == meta["size"]
+                assert len(check_md5s[obj_hashkey]) == meta['size']
     # The retrieved values should be only the valid ones
     assert set(missing) == set(unknown_hashkeys)
     check_md5s = {key: hashlib.md5(val).hexdigest() for key, val in contents.items()}
@@ -892,9 +893,9 @@ def test_same_object_loose(temp_container, generate_random_data):
     This is due to the deduplication provided by the hashing function."""
     # Check that there are no objects
     counts = temp_container.count_objects()
-    assert counts["packed"] == 0
-    assert counts["loose"] == 0
-    assert counts["pack_files"] == 0
+    assert counts['packed'] == 0
+    assert counts['loose'] == 0
+    assert counts['pack_files'] == 0
 
     num_objects = 100  # Write these many identical objects
 
@@ -904,13 +905,13 @@ def test_same_object_loose(temp_container, generate_random_data):
     for _ in range(num_objects):
         obj_hashkeys.append(temp_container.add_object(test_data))
 
-    assert len(set(obj_hashkeys)) == 1, "Objects are not all identical"
+    assert len(set(obj_hashkeys)) == 1, 'Objects are not all identical'
 
     # Check the number of objects again
     counts = temp_container.count_objects()
-    assert counts["packed"] == 0
-    assert counts["loose"] == 1
-    assert counts["pack_files"] == 0
+    assert counts['packed'] == 0
+    assert counts['loose'] == 1
+    assert counts['pack_files'] == 0
 
 
 def test_same_object_direct_pack(temp_container, generate_random_data):
@@ -919,9 +920,9 @@ def test_same_object_direct_pack(temp_container, generate_random_data):
     This is due to the deduplication provided by the hashing function."""
     # Check that there are no objects
     counts = temp_container.count_objects()
-    assert counts["packed"] == 0
-    assert counts["loose"] == 0
-    assert counts["pack_files"] == 0
+    assert counts['packed'] == 0
+    assert counts['loose'] == 0
+    assert counts['pack_files'] == 0
 
     num_objects = 100  # Write these many identical objects
 
@@ -932,58 +933,58 @@ def test_same_object_direct_pack(temp_container, generate_random_data):
 
     # Append all of them; it should understand it always the same
     obj_hashkeys = temp_container.add_objects_to_pack(all_test_data)
-    assert len(set(obj_hashkeys)) == 1, "Objects are not all identical"
+    assert len(set(obj_hashkeys)) == 1, 'Objects are not all identical'
 
     # Check the number of objects again
     counts = temp_container.count_objects()
-    assert counts["packed"] == 1
-    assert counts["loose"] == 0
-    assert counts["pack_files"] == 1
+    assert counts['packed'] == 1
+    assert counts['loose'] == 0
+    assert counts['pack_files'] == 1
 
     # Do it again; the object is already there
     new_obj_hashkeys = temp_container.add_objects_to_pack(all_test_data)
-    assert len(set(obj_hashkeys)) == 1, "Objects are not all identical"
+    assert len(set(obj_hashkeys)) == 1, 'Objects are not all identical'
     assert (
         obj_hashkeys[0] == new_obj_hashkeys[0]
-    ), "In the second insertion, it generated a different hash key"
+    ), 'In the second insertion, it generated a different hash key'
 
     # Check the number of objects again
     counts = temp_container.count_objects()
-    assert counts["packed"] == 1
-    assert counts["loose"] == 0
-    assert counts["pack_files"] == 1
+    assert counts['packed'] == 1
+    assert counts['loose'] == 0
+    assert counts['pack_files'] == 1
 
 
 def test_same_object_loose_and_pack(temp_container):
     """Store the same object first as loose, then pack all, then readd the same object and repack."""
     # Check that there are no objects
     counts = temp_container.count_objects()
-    assert counts["packed"] == 0
-    assert counts["loose"] == 0
-    assert counts["pack_files"] == 0
+    assert counts['packed'] == 0
+    assert counts['loose'] == 0
+    assert counts['pack_files'] == 0
 
-    test_data = b"fsdjkldf"
+    test_data = b'fsdjkldf'
     obj_hashkey = temp_container.add_object(test_data)
 
     # Check the number of objects: there should be a single loose object
     counts = temp_container.count_objects()
-    assert counts["packed"] == 0
-    assert counts["loose"] == 1
-    assert counts["pack_files"] == 0
+    assert counts['packed'] == 0
+    assert counts['loose'] == 1
+    assert counts['pack_files'] == 0
 
     temp_container.pack_all_loose()
     # Check the number of objects again; there should be only a single packed object in one pack file
     counts = temp_container.count_objects()
-    assert counts["packed"] == 1
-    assert counts["loose"] == 1  # still undeleted
-    assert counts["pack_files"] == 1
+    assert counts['packed'] == 1
+    assert counts['loose'] == 1  # still undeleted
+    assert counts['pack_files'] == 1
 
     # Clean up and remove loose objects that are already packed
     temp_container.clean_storage()
     counts = temp_container.count_objects()
-    assert counts["packed"] == 1
-    assert counts["loose"] == 0  # now removed
-    assert counts["pack_files"] == 1
+    assert counts['packed'] == 1
+    assert counts['loose'] == 0  # now removed
+    assert counts['pack_files'] == 1
 
     new_obj_hashkey = temp_container.add_object(test_data)
     assert new_obj_hashkey == obj_hashkey
@@ -996,14 +997,14 @@ def test_same_object_loose_and_pack(temp_container):
     temp_container.pack_all_loose()
     temp_container.clean_storage()
     counts = temp_container.count_objects()
-    assert counts["packed"] == 1
-    assert counts["loose"] == 0
-    assert counts["pack_files"] == 1
+    assert counts['packed'] == 1
+    assert counts['loose'] == 0
+    assert counts['pack_files'] == 1
 
 
-@pytest.mark.skipif(os.name != "nt", reason="This test only makes sense on Windows")
-@pytest.mark.parametrize("compress", [True, False])
-@pytest.mark.parametrize("open_only", [True, False])
+@pytest.mark.skipif(os.name != 'nt', reason='This test only makes sense on Windows')
+@pytest.mark.parametrize('compress', [True, False])
+@pytest.mark.parametrize('open_only', [True, False])
 def test_locked_object_while_packing(  # pylint: disable=invalid-name
     temp_container, lock_file_on_windows, open_only, compress
 ):
@@ -1011,19 +1012,19 @@ def test_locked_object_while_packing(  # pylint: disable=invalid-name
 
     :param open_only: if True, just open; if False, lock also for reading.
     """
-    content1 = b"2332"
-    content2 = b"wegaewf"
+    content1 = b'2332'
+    content2 = b'wegaewf'
 
     counts = temp_container.count_objects()
-    assert counts["packed"] == 0
-    assert counts["loose"] == 0
+    assert counts['packed'] == 0
+    assert counts['loose'] == 0
 
     hashkey1 = temp_container.add_object(content1)
     hashkey2 = temp_container.add_object(content2)
 
     counts = temp_container.count_objects()
-    assert counts["packed"] == 0
-    assert counts["loose"] == 2
+    assert counts['packed'] == 0
+    assert counts['loose'] == 2
 
     file_descriptor = os.open(
         temp_container._get_loose_path_from_hashkey(hashkey1),
@@ -1041,7 +1042,7 @@ def test_locked_object_while_packing(  # pylint: disable=invalid-name
     counts = temp_container.count_objects()
     # Both should have been packed if the loose object was simply open.
     # Otherwise, if it was locked, I couldn't do anything so it's still loose
-    assert counts["packed"] == (2 if open_only else 1)
+    assert counts['packed'] == (2 if open_only else 1)
 
     # Check I can get the content
     assert temp_container.get_object_content(hashkey1) == content1
@@ -1051,7 +1052,7 @@ def test_locked_object_while_packing(  # pylint: disable=invalid-name
     temp_container.pack_all_loose(compress=compress)
     counts = temp_container.count_objects()
     # Now should be both packed
-    assert counts["packed"] == 2
+    assert counts['packed'] == 2
 
     # Check I can get the content
     assert temp_container.get_object_content(hashkey1) == content1
@@ -1060,8 +1061,8 @@ def test_locked_object_while_packing(  # pylint: disable=invalid-name
 
 # Note that until when we want to support py3.5, we cannot specify the
 # level as a keyword argument, as this was added only in python 3.6
-@pytest.mark.parametrize("compression_algorithm", COMPRESSION_ALGORITHMS_TO_TEST)
-@pytest.mark.parametrize("compress_packs", [True, False])
+@pytest.mark.parametrize('compression_algorithm', COMPRESSION_ALGORITHMS_TO_TEST)
+@pytest.mark.parametrize('compress_packs', [True, False])
 def test_sizes(
     temp_container, generate_random_data, compress_packs, compression_algorithm
 ):
@@ -1070,14 +1071,14 @@ def test_sizes(
         clear=True, compression_algorithm=compression_algorithm
     )
     size_info = temp_container.get_total_size()
-    assert size_info["total_size_packed"] == 0
-    assert size_info["total_size_packed_on_disk"] == 0
-    assert size_info["total_size_packfiles_on_disk"] == 0
+    assert size_info['total_size_packed'] == 0
+    assert size_info['total_size_packed_on_disk'] == 0
+    assert size_info['total_size_packfiles_on_disk'] == 0
     assert (
-        size_info["total_size_packindexes_on_disk"]
+        size_info['total_size_packindexes_on_disk']
         == temp_container._get_pack_index_path().stat().st_size
     )
-    assert size_info["total_size_loose"] == 0
+    assert size_info['total_size_loose'] == 0
 
     data = generate_random_data()
     total_object_size = sum(len(value) for value in data.values())
@@ -1093,14 +1094,14 @@ def test_sizes(
 
     # Check the size for loose objects
     size_info = temp_container.get_total_size()
-    assert size_info["total_size_packed"] == 0
-    assert size_info["total_size_packed_on_disk"] == 0
-    assert size_info["total_size_packfiles_on_disk"] == 0
+    assert size_info['total_size_packed'] == 0
+    assert size_info['total_size_packed_on_disk'] == 0
+    assert size_info['total_size_packfiles_on_disk'] == 0
     assert (
-        size_info["total_size_packindexes_on_disk"]
+        size_info['total_size_packindexes_on_disk']
         == temp_container._get_pack_index_path().stat().st_size
     )
-    assert size_info["total_size_loose"] == total_object_size
+    assert size_info['total_size_loose'] == total_object_size
 
     # Pack without compression
     temp_container.pack_all_loose(compress=compress_packs)
@@ -1126,24 +1127,24 @@ def test_sizes(
         total_compressed_size = sum(len(value) for value in compressed_data.values())
 
         size_info = temp_container.get_total_size()
-        assert size_info["total_size_packed"] == total_object_size
-        assert size_info["total_size_packed_on_disk"] == total_compressed_size
-        assert size_info["total_size_packfiles_on_disk"] == total_compressed_size
+        assert size_info['total_size_packed'] == total_object_size
+        assert size_info['total_size_packed_on_disk'] == total_compressed_size
+        assert size_info['total_size_packfiles_on_disk'] == total_compressed_size
         assert (
-            size_info["total_size_packindexes_on_disk"]
+            size_info['total_size_packindexes_on_disk']
             == temp_container._get_pack_index_path().stat().st_size
         )
-        assert size_info["total_size_loose"] == 0
+        assert size_info['total_size_loose'] == 0
     else:
         size_info = temp_container.get_total_size()
-        assert size_info["total_size_packed"] == total_object_size
-        assert size_info["total_size_packed_on_disk"] == total_object_size
-        assert size_info["total_size_packfiles_on_disk"] == total_object_size
+        assert size_info['total_size_packed'] == total_object_size
+        assert size_info['total_size_packed_on_disk'] == total_object_size
+        assert size_info['total_size_packfiles_on_disk'] == total_object_size
         assert (
-            size_info["total_size_packindexes_on_disk"]
+            size_info['total_size_packindexes_on_disk']
             == temp_container._get_pack_index_path().stat().st_size
         )
-        assert size_info["total_size_loose"] == 0
+        assert size_info['total_size_loose'] == 0
 
 
 def test_close_twice(temp_dir):
@@ -1254,7 +1255,7 @@ def test_get_objects_stream_closes(temp_dir, generate_random_data):
         ##### Same test after adding at least one loose object
         ##############################
         new_object_content = (
-            b"1" * 20000
+            b'1' * 20000
         )  # This should be long enough not to collide with the generated random data
         new_hashkey = temp_container.add_object(new_object_content)
         obj_md5s[new_hashkey] = new_object_content
@@ -1316,20 +1317,18 @@ def test_deletion_closes_file_descriptors(temp_dir, generate_random_data):
         # Checks if initalisation actually opens files
         assert 0 < len(
             current_process.open_files()
-        ), "No files have been opened during initalisation"
+        ), 'No files have been opened during initalisation'
 
         # Checks if deleting the container will close the files
         del temp_container
 
         assert begin_test_open_files == len(current_process.open_files())
     finally:
-        if "temp_container" in locals():
-            locals()["temp_container"].close()
+        if 'temp_container' in locals():
+            locals()['temp_container'].close()
 
 
-def test_get_objects_meta_doesnt_open(
-    temp_container, generate_random_data
-):  # pylint: disable=invalid-name
+def test_get_objects_meta_doesnt_open(temp_container, generate_random_data):  # pylint: disable=invalid-name
     """Test that get_objects_meta does not open any file."""
     data = generate_random_data()
     # Store
@@ -1372,7 +1371,7 @@ def test_get_objects_meta_doesnt_open(
     ##### Same test after adding at least one loose object
     ##############################
     new_object_content = (
-        b"1" * 20000
+        b'1' * 20000
     )  # This should be long enough not to collide with the generated random data
     new_hashkey = temp_container.add_object(new_object_content)
     obj_md5s[new_hashkey] = new_object_content
@@ -1392,9 +1391,9 @@ def test_get_objects_meta_doesnt_open(
 
 # Note that until when we want to support py3.5, we cannot specify the
 # level as a keyword argument, as this was added only in python 3.6
-@pytest.mark.parametrize("compression_algorithm", COMPRESSION_ALGORITHMS_TO_TEST)
-@pytest.mark.parametrize("compress", [True, False])
-@pytest.mark.parametrize("skip_if_missing", [True, False])
+@pytest.mark.parametrize('compression_algorithm', COMPRESSION_ALGORITHMS_TO_TEST)
+@pytest.mark.parametrize('compress', [True, False])
+@pytest.mark.parametrize('skip_if_missing', [True, False])
 def test_stream_meta(  # pylint: disable=too-many-locals
     temp_container, compress, skip_if_missing, compression_algorithm
 ):
@@ -1408,21 +1407,21 @@ def test_stream_meta(  # pylint: disable=too-many-locals
     # but I put this here to make sure in the future, if I change the interface and adapt the keys, I don't break
     # this guarantee if I forget to adapt the test.
     known_meta_keys = [
-        "type",
-        "size",
-        "pack_id",
-        "pack_compressed",
-        "pack_offset",
-        "pack_length",
+        'type',
+        'size',
+        'pack_id',
+        'pack_compressed',
+        'pack_offset',
+        'pack_length',
     ]
 
-    content_packed = b"sffssdf383939"
-    content_loose = b"v9fpaM"
+    content_packed = b'sffssdf383939'
+    content_loose = b'v9fpaM'
     hashkey_packed = temp_container.add_objects_to_pack(
         [content_packed], compress=compress
     )[0]
     hashkey_loose = temp_container.add_object(content_loose)
-    hashkey_missing = "unknown"
+    hashkey_missing = 'unknown'
     compresser = utils.get_compressobj_instance(compression_algorithm)
     content_packed_compressed = compresser.compress(content_packed)
     content_packed_compressed += compresser.flush()
@@ -1432,8 +1431,8 @@ def test_stream_meta(  # pylint: disable=too-many-locals
 
     expected_skip_missing_true = {
         hashkey_packed: {
-            "content": content_packed,
-            "meta": ObjectMeta(
+            'content': content_packed,
+            'meta': ObjectMeta(
                 type=ObjectType.PACKED,
                 size=len(content_packed),
                 pack_id=0,  # First pack, it's a new container
@@ -1443,8 +1442,8 @@ def test_stream_meta(  # pylint: disable=too-many-locals
             ),
         },
         hashkey_loose: {
-            "content": content_loose,
-            "meta": ObjectMeta(
+            'content': content_loose,
+            'meta': ObjectMeta(
                 type=ObjectType.LOOSE,
                 size=len(content_loose),
                 pack_id=None,
@@ -1457,8 +1456,8 @@ def test_stream_meta(  # pylint: disable=too-many-locals
 
     expected_skip_missing_false = expected_skip_missing_true.copy()
     expected_skip_missing_false[hashkey_missing] = {
-        "content": None,
-        "meta": ObjectMeta(
+        'content': None,
+        'meta': ObjectMeta(
             type=ObjectType.MISSING,
             size=None,
             pack_id=None,
@@ -1475,13 +1474,13 @@ def test_stream_meta(  # pylint: disable=too-many-locals
     ) as triplets:
         # I loop over the triplets, but I don't do anything
         for hashkey, stream, meta in triplets:
-            retdict = {"meta": meta}
+            retdict = {'meta': meta}
             # In any case I should return all these meta, and no more
             assert set(dataclasses.asdict(meta).keys()) == set(known_meta_keys)
             if stream is None:
-                retdict["content"] = None
+                retdict['content'] = None
             else:
-                retdict["content"] = stream.read()
+                retdict['content'] = stream.read()
             check_dict[hashkey] = retdict
 
     if skip_if_missing:
@@ -1499,18 +1498,18 @@ def test_stream_meta(  # pylint: disable=too-many-locals
 
     if skip_if_missing:
         assert check_dict == {
-            k: v["meta"] for k, v in expected_skip_missing_true.items()
+            k: v['meta'] for k, v in expected_skip_missing_true.items()
         }
     else:
         assert check_dict == {
-            k: v["meta"] for k, v in expected_skip_missing_false.items()
+            k: v['meta'] for k, v in expected_skip_missing_false.items()
         }
 
 
 # Note that until when we want to support py3.5, we cannot specify the
 # level as a keyword argument, as this was added only in python 3.6
-@pytest.mark.parametrize("compression_algorithm", COMPRESSION_ALGORITHMS_TO_TEST)
-@pytest.mark.parametrize("compress", [True, False])
+@pytest.mark.parametrize('compression_algorithm', COMPRESSION_ALGORITHMS_TO_TEST)
+@pytest.mark.parametrize('compress', [True, False])
 def test_stream_meta_single(temp_container, compress, compression_algorithm):
     """Validate the meta dictionary returned by the single-object methods.
 
@@ -1524,21 +1523,21 @@ def test_stream_meta_single(temp_container, compress, compression_algorithm):
     # but I put this here to make sure in the future, if I change the interface and adapt the keys, I don't break
     # this guarantee if I forget to adapt the test.
     known_meta_keys = [
-        "type",
-        "size",
-        "pack_id",
-        "pack_compressed",
-        "pack_offset",
-        "pack_length",
+        'type',
+        'size',
+        'pack_id',
+        'pack_compressed',
+        'pack_offset',
+        'pack_length',
     ]
 
-    content_packed = b"sffssdf383939"
-    content_loose = b"v9fpaM"
+    content_packed = b'sffssdf383939'
+    content_loose = b'v9fpaM'
     hashkey_packed = temp_container.add_objects_to_pack(
         [content_packed], compress=compress
     )[0]
     hashkey_loose = temp_container.add_object(content_loose)
-    hashkey_missing = "unknown"
+    hashkey_missing = 'unknown'
     compresser = utils.get_compressobj_instance(compression_algorithm)
     content_packed_compressed = compresser.compress(content_packed)
     content_packed_compressed += compresser.flush()
@@ -1548,8 +1547,8 @@ def test_stream_meta_single(temp_container, compress, compression_algorithm):
 
     expected_skip_missing_true = {
         hashkey_packed: {
-            "content": content_packed,
-            "meta": ObjectMeta(
+            'content': content_packed,
+            'meta': ObjectMeta(
                 type=ObjectType.PACKED,
                 size=len(content_packed),
                 pack_id=0,  # First pack, it's a new container
@@ -1559,8 +1558,8 @@ def test_stream_meta_single(temp_container, compress, compression_algorithm):
             ),
         },
         hashkey_loose: {
-            "content": content_loose,
-            "meta": ObjectMeta(
+            'content': content_loose,
+            'meta': ObjectMeta(
                 type=ObjectType.LOOSE,
                 size=len(content_loose),
                 pack_id=None,
@@ -1575,13 +1574,13 @@ def test_stream_meta_single(temp_container, compress, compression_algorithm):
 
     for hashkey in [hashkey_packed, hashkey_loose]:
         with temp_container.get_object_stream_and_meta(hashkey) as (stream, meta):
-            retdict = {"meta": meta}
+            retdict = {'meta': meta}
             # In any case I should return all these meta, and no more
             assert set(dataclasses.asdict(meta).keys()) == set(known_meta_keys)
             if stream is None:
-                retdict["content"] = None
+                retdict['content'] = None
             else:
-                retdict["content"] = stream.read()
+                retdict['content'] = stream.read()
             check_dict[hashkey] = retdict
     assert check_dict == expected_skip_missing_true
 
@@ -1596,7 +1595,7 @@ def test_stream_meta_single(temp_container, compress, compression_algorithm):
     for hashkey in [hashkey_packed, hashkey_loose]:
         check_dict[hashkey] = temp_container.get_object_meta(hashkey)
 
-    assert check_dict == {k: v["meta"] for k, v in expected_skip_missing_true.items()}
+    assert check_dict == {k: v['meta'] for k, v in expected_skip_missing_true.items()}
 
     with pytest.raises(exc.NotExistent):
         meta = temp_container.get_object_meta(hashkey_missing)
@@ -1608,7 +1607,7 @@ def test_length_get_objects(temp_container):
     This is mostly to check for efficiency and that I don't iterate by mistake multiple times on the same object.
     """
     # Note: I created different data, so these 4 hashkeys will always be different
-    data = [b"1", b"2", b"3", b"4"]
+    data = [b'1', b'2', b'3', b'4']
     data_dict = {}
     for val in data:
         hashkey = temp_container.add_object(val)
@@ -1642,7 +1641,7 @@ def test_length_get_objects(temp_container):
 
     # Test 4A: I pass half the known hashkeys, twice, PLUS SOME UNKNOWN HASHKEY, also twice
     # If skip_if_missing=False, I should iterate on ALL of them, BUT ONLY ONCE
-    unknown_hashkeys = ["unk1", "unk2"]
+    unknown_hashkeys = ['unk1', 'unk2']
     partial_hashkeys = list(data_dict)[:2]
     hashkeys = partial_hashkeys + partial_hashkeys + unknown_hashkeys + unknown_hashkeys
     iterated_hashkeys = []
@@ -1656,7 +1655,7 @@ def test_length_get_objects(temp_container):
 
     # Test 4B: I pass half the known hashkeys, twice, PLUS SOME UNKNOWN HASHKEY, also twice
     # If skip_if_missing=True, I should iterate ONLY on the known one, BUT ONLY ONCE
-    unknown_hashkeys = ["unk1", "unk2"]
+    unknown_hashkeys = ['unk1', 'unk2']
     partial_hashkeys = list(data_dict)[:2]
     hashkeys = partial_hashkeys + partial_hashkeys + unknown_hashkeys + unknown_hashkeys
     iterated_hashkeys = []
@@ -1685,11 +1684,11 @@ def test_very_long_hashkeys_list(temp_container):
     # (because I'm writing loose objects as well)
     num_objects = temp_container._IN_SQL_MAX_LENGTH * 10 + 3
     # Generate a long list of objects with *different* data, so they are not deduplicated
-    data = [str(i).encode("ascii") for i in range(num_objects)]
+    data = [str(i).encode('ascii') for i in range(num_objects)]
 
     # The container is empty: let's check that asking for unknown objects work
     # NOTE: I just generate some random 'unknown' hash key
-    res = temp_container.get_objects_content([f"unk{i}" for i in range(num_objects)])
+    res = temp_container.get_objects_content([f'unk{i}' for i in range(num_objects)])
     assert not res
 
     # I now add all objects
@@ -1715,7 +1714,7 @@ def test_very_long_hashkeys_list(temp_container):
 
     # Create more data, different than the one before and add directly to packs, this time.
     # This should also work
-    direct_pack_data = [f"P{i}".encode("ascii") for i in range(num_objects)]
+    direct_pack_data = [f'P{i}'.encode('ascii') for i in range(num_objects)]
     direct_pack_hashkeys = temp_container.add_objects_to_pack(direct_pack_data)
 
     # Finally, ask back everything and check
@@ -1725,12 +1724,10 @@ def test_very_long_hashkeys_list(temp_container):
     assert values == expected_values
 
 
-@pytest.mark.parametrize("compress", [True, False])
-def test_simulate_concurrent_packing(
-    temp_container, compress
-):  # pylint: disable=invalid-name
+@pytest.mark.parametrize('compress', [True, False])
+def test_simulate_concurrent_packing(temp_container, compress):  # pylint: disable=invalid-name
     """Simulate race conditions while reading and packing."""
-    content = b"abc"
+    content = b'abc'
     hashkey = temp_container.add_object(content)
 
     loose_dir_path = pathlib.Path(temp_container._get_loose_folder())
@@ -1738,9 +1735,9 @@ def test_simulate_concurrent_packing(
         fpath = pathlib.Path(fhandle.name)
         # Check that this is a loose object (i.e. that it is in the loose folder)
         assert loose_dir_path in fpath.parents
-        assert fhandle.read(1) == b"a"
+        assert fhandle.read(1) == b'a'
         temp_container.pack_all_loose(compress=compress)
-        assert fhandle.read() == b"bc"
+        assert fhandle.read() == b'bc'
 
         # Remove loose files
         temp_container.clean_storage()
@@ -1752,21 +1749,19 @@ def test_simulate_concurrent_packing(
     # The following line should be read from the pack file. Anyway, the important thing to test
     # is that the content is properly returned.
     with temp_container.get_object_stream(hashkey) as fhandle:
-        assert fhandle.read() == b"abc"
+        assert fhandle.read() == b'abc'
 
     # After a second cleaning of the storage, the loose file *must* have been removed on all OSs
     temp_container.clean_storage()
     assert not fpath.exists()
 
 
-@pytest.mark.parametrize("do_vacuum", [True, False])
-@pytest.mark.parametrize("compress", [True, False])
-def test_simulate_concurrent_packing_multiple(
-    temp_container, compress, do_vacuum
-):  # pylint: disable=invalid-name
+@pytest.mark.parametrize('do_vacuum', [True, False])
+@pytest.mark.parametrize('compress', [True, False])
+def test_simulate_concurrent_packing_multiple(temp_container, compress, do_vacuum):  # pylint: disable=invalid-name
     """Simulate race conditions while reading and packing."""
-    content1 = b"abc"
-    content2 = b"def"
+    content1 = b'abc'
+    content2 = b'def'
     hashkey1 = temp_container.add_object(content1)
     hashkey2 = temp_container.add_object(content2)
     data = {hashkey1: content1, hashkey2: content2}
@@ -1782,20 +1777,20 @@ def test_simulate_concurrent_packing_multiple(
                 # Check that this is a loose object (i.e. that it is in the loose folder)
                 assert loose_dir_path in fpath.parents
                 if obj_hashkey == hashkey1:
-                    assert stream.read(1) == b"a"
+                    assert stream.read(1) == b'a'
                     temp_container.pack_all_loose(compress=compress)
                     # Remove loose files
                     temp_container.clean_storage(vacuum=do_vacuum)
-                    assert stream.read() == b"bc"
+                    assert stream.read() == b'bc'
                 elif obj_hashkey == hashkey2:
-                    assert stream.read(1) == b"d"
+                    assert stream.read(1) == b'd'
                     temp_container.pack_all_loose(compress=compress)
                     # Remove loose files
                     temp_container.clean_storage(vacuum=do_vacuum)
-                    assert stream.read() == b"ef"
+                    assert stream.read() == b'ef'
                 else:
                     # Should not happen!
-                    raise ValueError(f"Unknown hash key {obj_hashkey}")
+                    raise ValueError(f'Unknown hash key {obj_hashkey}')
             elif counter == 1:
                 # This should be the other object
                 # This was loose when get_objects_stream_and_meta was called, but was packed in the meantime
@@ -1803,7 +1798,7 @@ def test_simulate_concurrent_packing_multiple(
                 assert data[obj_hashkey] == stream.read()
             else:
                 # Should not happen!
-                raise ValueError("There should be only two objects!")
+                raise ValueError('There should be only two objects!')
             counter += 1
 
     # On Windows, the loose file might still be there because I cannot delete an open file
@@ -1824,14 +1819,14 @@ def test_simulate_concurrent_packing_multiple_many(
     expected = {}
 
     # I put at least one object already packed
-    preliminary_content = b"AAA"
+    preliminary_content = b'AAA'
     preliminary_hashkey = temp_container.add_object(preliminary_content)
     temp_container.pack_all_loose()
     temp_container.clean_storage()
     expected[preliminary_hashkey] = preliminary_content
 
     for idx in range(temp_container._MAX_CHUNK_ITERATE_LENGTH + 10):
-        content = f"{idx}".encode("ascii")
+        content = f'{idx}'.encode('ascii')
         expected[temp_container.add_object(content)] = content
 
     retrieved = {}
@@ -1842,7 +1837,7 @@ def test_simulate_concurrent_packing_multiple_many(
             if first:
                 # I should have found only one packed object (preliminary_content).
                 assert obj_hashkey == preliminary_hashkey
-                assert meta["type"] == ObjectType.PACKED
+                assert meta['type'] == ObjectType.PACKED
                 # I will not look for the loose until I exhaust the packed objects.
                 # In the meantime, therefore, I pack all the rest, and I clean the storage:
                 # this will trigger the fallback logic to check again if there are
@@ -1854,13 +1849,11 @@ def test_simulate_concurrent_packing_multiple_many(
     assert expected == retrieved
 
 
-@pytest.mark.parametrize("compress", [True, False])
-def test_simulate_concurrent_packing_multiple_meta_only(
-    temp_container, compress
-):  # pylint: disable=invalid-name
+@pytest.mark.parametrize('compress', [True, False])
+def test_simulate_concurrent_packing_multiple_meta_only(temp_container, compress):  # pylint: disable=invalid-name
     """Simulate race conditions while reading and packing (as earlier function, but no streams)."""
-    content1 = b"abc"
-    content2 = b"def"
+    content1 = b'abc'
+    content2 = b'def'
     hashkey1 = temp_container.add_object(content1)
     hashkey2 = temp_container.add_object(content2)
 
@@ -1870,7 +1863,7 @@ def test_simulate_concurrent_packing_multiple_meta_only(
             # In the first step, I always pack the rest
 
             # Check that this is a loose object
-            assert meta["type"] == ObjectType.LOOSE
+            assert meta['type'] == ObjectType.LOOSE
             temp_container.pack_all_loose(compress=compress)
             # Remove loose files
             temp_container.clean_storage()
@@ -1878,25 +1871,23 @@ def test_simulate_concurrent_packing_multiple_meta_only(
             # This should be the other object
             # This was loose when get_objects_stream_and_meta was called, but was packed in the meantime
             # I should still be able to get it correctly and discover it's packed
-            assert meta["type"] == ObjectType.PACKED
+            assert meta['type'] == ObjectType.PACKED
         else:
             # Should not happen!
-            raise ValueError("There should be only two objects!")
+            raise ValueError('There should be only two objects!')
         counter += 1
 
 
-@pytest.mark.parametrize("compress", [True, False])
-def test_simulate_concurrent_packing_multiple_existing_pack(
-    temp_container, compress
-):  # pylint: disable=invalid-name
+@pytest.mark.parametrize('compress', [True, False])
+def test_simulate_concurrent_packing_multiple_existing_pack(temp_container, compress):  # pylint: disable=invalid-name
     """Simulate race conditions while reading and packing.
 
     In addition, this does it when the first file is not loose, but it is already packed.
     This triggers some lines of code to close the packs if already open, increasing test coverage
     and implicitly testing that open file leaks are avoided.
     """
-    content1 = b"abc"
-    content2 = b"def"
+    content1 = b'abc'
+    content2 = b'def'
 
     hashkey1 = temp_container.add_objects_to_pack([content1], compress=compress)[0]
     hashkey2 = temp_container.add_object(content2)
@@ -1923,7 +1914,7 @@ def test_simulate_concurrent_packing_multiple_existing_pack(
                 assert stream.read() == content2
             else:
                 # Should not happen!
-                raise ValueError("There should be only two objects!")
+                raise ValueError('There should be only two objects!')
             counter += 1
 
     # Object #2 was not open during the packing operation. Theferore, it should be deleted during packing
@@ -1933,11 +1924,11 @@ def test_simulate_concurrent_packing_multiple_existing_pack(
 
 def test_has_objects(temp_container):
     """Test the ``Container.has_objects`` method."""
-    unknown_hashkey = "unk"
+    unknown_hashkey = 'unk'
 
     # Create an object and test that `has_object` recognizes it
-    hashkey_pack1 = temp_container.add_object(b"1")
-    hashkey_pack2 = temp_container.add_object(b"2")
+    hashkey_pack1 = temp_container.add_object(b'1')
+    hashkey_pack2 = temp_container.add_object(b'2')
     assert temp_container.has_objects([hashkey_pack1, hashkey_pack2]) == [True, True]
     assert temp_container.has_objects(
         [hashkey_pack2, unknown_hashkey, hashkey_pack1]
@@ -1951,8 +1942,8 @@ def test_has_objects(temp_container):
     ) == [True, False, True]
 
     # Add a few more loose objects, and check that all works also with mixed loose and packed objects
-    hashkey_loose1 = temp_container.add_object(b"3")
-    hashkey_loose2 = temp_container.add_object(b"4")
+    hashkey_loose1 = temp_container.add_object(b'3')
+    hashkey_loose2 = temp_container.add_object(b'4')
     assert temp_container.has_objects([hashkey_pack1, hashkey_pack2]) == [True, True]
     assert temp_container.has_objects(
         [hashkey_pack2, unknown_hashkey, hashkey_pack1]
@@ -1968,10 +1959,10 @@ def test_has_objects(temp_container):
 
 def test_has_object(temp_container):
     """Test the ``Container.has_object`` method."""
-    assert not temp_container.has_object("unk")
+    assert not temp_container.has_object('unk')
 
     # Create an object and test that `has_object` recognizes it
-    hashkey = temp_container.add_object(b"1")
+    hashkey = temp_container.add_object(b'1')
     assert temp_container.has_object(hashkey)
 
     # Verify that it still works after packing the object
@@ -1979,10 +1970,10 @@ def test_has_object(temp_container):
     assert temp_container.has_object(hashkey)
 
 
-@pytest.mark.parametrize("compress", [True, False])
+@pytest.mark.parametrize('compress', [True, False])
 def test_seek_tell(temp_container, compress):
     """Test the tell and seek methods of returned objects."""
-    content = b"0123456789"
+    content = b'0123456789'
     hashkey = temp_container.add_object(content)
 
     seek_pos = 3
@@ -1990,7 +1981,7 @@ def test_seek_tell(temp_container, compress):
 
     # Check that the seek and tell method work for loose objects
     with temp_container.get_object_stream_and_meta(hashkey) as (fhandle, meta):
-        assert meta["type"] == ObjectType.LOOSE
+        assert meta['type'] == ObjectType.LOOSE
         fhandle.seek(seek_pos)
         assert fhandle.tell() == seek_pos
         read_data = fhandle.read(read_length)
@@ -2002,8 +1993,8 @@ def test_seek_tell(temp_container, compress):
 
     # Check that the seek and tell method work for packed objects (either compressed or not)
     with temp_container.get_object_stream_and_meta(hashkey) as (fhandle, meta):
-        assert meta["type"] == ObjectType.PACKED
-        assert meta["pack_compressed"] == compress
+        assert meta['type'] == ObjectType.PACKED
+        assert meta['pack_compressed'] == compress
         fhandle.seek(seek_pos)
         assert fhandle.tell() == seek_pos
         read_data = fhandle.read(read_length)
@@ -2014,7 +2005,7 @@ def test_seek_tell(temp_container, compress):
 def test_get_objects_meta_to_dict(temp_container):
     """Check that you can just wrap `get_objects_meta` into a dict."""
     expected_sizes = {}
-    for content in [b"a", b"aa", b"aaaa"]:  # Data of diffenent length
+    for content in [b'a', b'aa', b'aaaa']:  # Data of diffenent length
         hashkey = temp_container.add_object(content)
         expected_sizes[hashkey] = len(content)
 
@@ -2022,14 +2013,14 @@ def test_get_objects_meta_to_dict(temp_container):
     hashkeys = list(expected_sizes)
     meta_dict = dict(temp_container.get_objects_meta(hashkeys))
     # Check tha the dict contains the right data
-    assert all(meta["type"] == ObjectType.LOOSE for meta in meta_dict.values())
+    assert all(meta['type'] == ObjectType.LOOSE for meta in meta_dict.values())
 
     assert expected_sizes == {
-        hashkey: meta["size"] for hashkey, meta in meta_dict.items()
+        hashkey: meta['size'] for hashkey, meta in meta_dict.items()
     }
 
 
-@pytest.mark.parametrize("loose_prefix_len", [0, 2, 3])
+@pytest.mark.parametrize('loose_prefix_len', [0, 2, 3])
 def test_list_all_objects(temp_dir, loose_prefix_len):
     """Test listing all objects in the container."""
     temp_container = Container(temp_dir)
@@ -2037,7 +2028,7 @@ def test_list_all_objects(temp_dir, loose_prefix_len):
 
     num_files = 1000
 
-    data_content = [f"{i}".encode("ascii") for i in range(num_files)]
+    data_content = [f'{i}'.encode('ascii') for i in range(num_files)]
     hashkeys = []
     for content in data_content:
         hashkeys.append(temp_container.add_object(content))
@@ -2048,7 +2039,7 @@ def test_list_all_objects(temp_dir, loose_prefix_len):
     assert sorted(hashkeys) == sorted(retval)
 
     temp_container.pack_all_loose()
-    assert temp_container.count_objects()["packed"] > 0
+    assert temp_container.count_objects()['packed'] > 0
 
     # Pack all objects, loose objects will remain in place
     # Check that all works and that I don't get duplicates
@@ -2064,7 +2055,7 @@ def test_list_all_objects(temp_dir, loose_prefix_len):
     assert sorted(hashkeys) == sorted(retval)
 
     # New data, different values
-    data_content2 = [f"second-{i}".encode("ascii") for i in range(num_files)]
+    data_content2 = [f'second-{i}'.encode('ascii') for i in range(num_files)]
     hashkeys2 = []
     for content in data_content2:
         hashkeys2.append(temp_container.add_object(content))
@@ -2090,17 +2081,15 @@ def test_list_all_objects(temp_dir, loose_prefix_len):
     temp_container.close()
 
 
-@pytest.mark.parametrize("loose_prefix_len", [0, 2, 3])
-def test_list_all_objects_extraneous(
-    temp_dir, loose_prefix_len
-):  # pylint: disable=invalid-name
+@pytest.mark.parametrize('loose_prefix_len', [0, 2, 3])
+def test_list_all_objects_extraneous(temp_dir, loose_prefix_len):  # pylint: disable=invalid-name
     """Test `list_all_objects` and check that files that do not match the format of a hash key are ignored."""
     temp_container = Container(temp_dir)
     temp_container.init_container(clear=True, loose_prefix_len=loose_prefix_len)
 
     num_files = 1000
 
-    data_content = [f"{i}".encode("ascii") for i in range(num_files)]
+    data_content = [f'{i}'.encode('ascii') for i in range(num_files)]
     hashkeys = []
     for content in data_content:
         hashkeys.append(temp_container.add_object(content))
@@ -2110,11 +2099,11 @@ def test_list_all_objects_extraneous(
     assert sorted(hashkeys) == sorted(retval)
 
     # I now add extraneous files that do not contain hex strings or have the wrong length
-    os.mkdir(temp_container._get_loose_folder() / "INVALID_NAME")
+    os.mkdir(temp_container._get_loose_folder() / 'INVALID_NAME')
 
     if loose_prefix_len != 0:
-        prefix = "0" * 2 * loose_prefix_len
-        suffix = "0" * 10
+        prefix = '0' * 2 * loose_prefix_len
+        suffix = '0' * 10
 
         # This is not really needed (actually, in the future we might also want to check the length)
         # but in that case we want to adapt the test to have a valid suffix: what I want to test is
@@ -2125,19 +2114,19 @@ def test_list_all_objects_extraneous(
         invalid_first_level = temp_container._get_loose_folder() / prefix
         os.mkdir(invalid_first_level)
         # Create an empty file
-        with open(invalid_first_level / suffix, "wb"):
+        with open(invalid_first_level / suffix, 'wb'):
             pass
 
         # creating now a valid first_level folder (if not present already), and an invalid name inside it
         first_level_subfolder = temp_container._get_loose_folder() / (
-            "0" * loose_prefix_len
+            '0' * loose_prefix_len
         )
         try:
             # Creating if it does not exist - this is a valid name
             os.mkdir(first_level_subfolder)
         except FileExistsError:
             pass
-        with open(first_level_subfolder / "INVALID_NAME", "wb"):
+        with open(first_level_subfolder / 'INVALID_NAME', 'wb'):
             pass
 
     # We list again: all invalid objects should just be ignored
@@ -2152,11 +2141,11 @@ def test_list_all_objects_extraneous(
 # with a memory of 9, we put the first object in the cache (6 bytes) and the second
 # will need to flush the cache. With a single byte, all objects don't fit the cache so
 # we need to copy directly from stream to stream, without going via the cache.
-@pytest.mark.parametrize("target_memory_bytes", [1, 9, 100 * 1024 * 1024])
-@pytest.mark.parametrize("compress_dest", [True, False])
-@pytest.mark.parametrize("compress_source", [True, False])
+@pytest.mark.parametrize('target_memory_bytes', [1, 9, 100 * 1024 * 1024])
+@pytest.mark.parametrize('compress_dest', [True, False])
+@pytest.mark.parametrize('compress_source', [True, False])
 # Test both the same hash and another one
-@pytest.mark.parametrize("other_container_hash_type", ["sha256", "sha1"])
+@pytest.mark.parametrize('other_container_hash_type', ['sha256', 'sha1'])
 def test_import_to_pack(
     temp_container,
     compress_source,
@@ -2165,9 +2154,9 @@ def test_import_to_pack(
     other_container_hash_type,
 ):
     """Test the functionality to import from another container."""
-    obj1 = b"111111"
-    obj2 = b"222222"
-    obj3 = b"333332"
+    obj1 = b'111111'
+    obj2 = b'222222'
+    obj3 = b'333332'
 
     with tempfile.TemporaryDirectory() as tmpdir:
         other_container = Container(tmpdir)
@@ -2180,10 +2169,10 @@ def test_import_to_pack(
         )
 
         # Initial state
-        assert temp_container.count_objects()["loose"] == 1
-        assert temp_container.count_objects()["packed"] == 2
-        assert other_container.count_objects()["loose"] == 0
-        assert other_container.count_objects()["packed"] == 0
+        assert temp_container.count_objects()['loose'] == 1
+        assert temp_container.count_objects()['packed'] == 2
+        assert other_container.count_objects()['loose'] == 0
+        assert other_container.count_objects()['packed'] == 0
 
         # Put only two objects
         old_new_mapping = other_container.import_objects(
@@ -2193,8 +2182,8 @@ def test_import_to_pack(
             target_memory_bytes=target_memory_bytes,
         )
         # Two objects should appear
-        assert other_container.count_objects()["loose"] == 0
-        assert other_container.count_objects()["packed"] == 2
+        assert other_container.count_objects()['loose'] == 0
+        assert other_container.count_objects()['packed'] == 2
 
         # Check the content, and that they are all the objects that exist
         assert other_container.get_object_content(old_new_mapping[hashkey1]) == obj1
@@ -2214,8 +2203,8 @@ def test_import_to_pack(
             )
         )
         # All three objects should be there, no duplicates
-        assert other_container.count_objects()["loose"] == 0
-        assert other_container.count_objects()["packed"] == 3
+        assert other_container.count_objects()['loose'] == 0
+        assert other_container.count_objects()['packed'] == 3
         assert set(other_container.list_all_objects()) == {
             old_new_mapping[hashkey1],
             old_new_mapping[hashkey2],
@@ -2235,13 +2224,13 @@ def test_import_to_pack(
         other_container.close()
 
 
-@pytest.mark.parametrize("compress", [True, False])
+@pytest.mark.parametrize('compress', [True, False])
 def test_validate(temp_container, compress):
     """Test the validation function."""
-    obj1 = b"324r3w"  # Will be packed (from loose)
-    obj2 = b"jklf2wv"  # Will be loose
-    obj3 = b"9z0vx0"  # Will be stored directly packed
-    obj4 = b"jkljkljlk"  # Will be stored directly packed
+    obj1 = b'324r3w'  # Will be packed (from loose)
+    obj2 = b'jklf2wv'  # Will be loose
+    obj3 = b'9z0vx0'  # Will be stored directly packed
+    obj4 = b'jkljkljlk'  # Will be stored directly packed
 
     # An empy container should be valid
     issues = temp_container.validate()
@@ -2270,7 +2259,7 @@ def test_validate(temp_container, compress):
 
 def test_validate_corrupt_loose(temp_container):
     """Test the validation function."""
-    obj1 = b"jklsfjsdlkdj"
+    obj1 = b'jklsfjsdlkdj'
 
     hashkey1 = temp_container.add_object(obj1)
 
@@ -2280,13 +2269,13 @@ def test_validate_corrupt_loose(temp_container):
     assert issues.is_valid()
 
     # Corrupt the object
-    with open(temp_container._get_loose_path_from_hashkey(hashkey1), "wb") as fhandle:
-        fhandle.write(b"CORRUPT")
+    with open(temp_container._get_loose_path_from_hashkey(hashkey1), 'wb') as fhandle:
+        fhandle.write(b'CORRUPT')
 
     # I don't use the dataclass .is_valid() method of ValidationIssues because I want to
     # pop the error and check that there are no other issues but only the one I'm aware of
     errors = dataclasses.asdict(temp_container.validate())
-    problems = errors.pop("invalid_hashes_loose")
+    problems = errors.pop('invalid_hashes_loose')
 
     assert set(problems) == {hashkey1}
 
@@ -2296,11 +2285,11 @@ def test_validate_corrupt_loose(temp_container):
 
 def test_validate_corrupt_packed(temp_container):
     """Test the validation function."""
-    obj1 = b"jklsfjsdlkdj"
+    obj1 = b'jklsfjsdlkdj'
 
     hashkey1 = temp_container.add_objects_to_pack([obj1], compress=False)[0]
     meta = temp_container.get_object_meta(hashkey1)
-    assert meta["type"] == ObjectType.PACKED
+    assert meta['type'] == ObjectType.PACKED
 
     # No errors yet
     temp_container.validate()
@@ -2309,14 +2298,14 @@ def test_validate_corrupt_packed(temp_container):
 
     # Corrupt the object
     with open(
-        temp_container._get_pack_path_from_pack_id(str(meta["pack_id"])), "wb"
+        temp_container._get_pack_path_from_pack_id(str(meta['pack_id'])), 'wb'
     ) as fhandle:
-        fhandle.write(b"CORRU890890890809PT")
+        fhandle.write(b'CORRU890890890809PT')
 
     # I don't use the dataclass .is_valid() method of ValidationIssues because I want to
     # pop the error and check that there are no other issues but only the one I'm aware of
     errors = dataclasses.asdict(temp_container.validate())
-    problems = errors.pop("invalid_hashes_packed")
+    problems = errors.pop('invalid_hashes_packed')
 
     assert set(problems) == {hashkey1}
 
@@ -2327,18 +2316,18 @@ def test_validate_corrupt_packed(temp_container):
 def test_validate_overlapping_packed(temp_container):  # pylint: disable=invalid-name
     """Test the validation function."""
     # Both of length 10
-    obj1 = b"0123456789"
-    obj2 = b"a123456789"
+    obj1 = b'0123456789'
+    obj2 = b'a123456789'
 
     hashkey1, hashkey2 = temp_container.add_objects_to_pack([obj1, obj2])
     meta1 = temp_container.get_object_meta(hashkey1)
     meta2 = temp_container.get_object_meta(hashkey2)
-    assert meta1["type"] == ObjectType.PACKED
-    assert meta2["type"] == ObjectType.PACKED
+    assert meta1['type'] == ObjectType.PACKED
+    assert meta2['type'] == ObjectType.PACKED
 
     # Hashkey of the object stored later in the pack
     hashkey_second = (
-        hashkey2 if meta1["pack_offset"] < meta2["pack_offset"] else hashkey1
+        hashkey2 if meta1['pack_offset'] < meta2['pack_offset'] else hashkey1
     )
 
     # No errors yet
@@ -2352,7 +2341,7 @@ def test_validate_overlapping_packed(temp_container):  # pylint: disable=invalid
     ).update({database.Obj.offset: database.Obj.offset - 1})
 
     errors = dataclasses.asdict(temp_container.validate())
-    problems = errors.pop("overlapping_packed")
+    problems = errors.pop('overlapping_packed')
 
     assert set(problems) == {hashkey_second}
 
@@ -2361,11 +2350,11 @@ def test_validate_overlapping_packed(temp_container):  # pylint: disable=invalid
 
 def test_validate_corrupt_packed_size(temp_container):  # pylint: disable=invalid-name
     """Test the validation function."""
-    obj1 = b"jklsfjsdlkdj"
+    obj1 = b'jklsfjsdlkdj'
 
     hashkey1 = temp_container.add_objects_to_pack([obj1], compress=False)[0]
     meta = temp_container.get_object_meta(hashkey1)
-    assert meta["type"] == ObjectType.PACKED
+    assert meta['type'] == ObjectType.PACKED
 
     # No errors yet
     temp_container.validate()
@@ -2374,18 +2363,18 @@ def test_validate_corrupt_packed_size(temp_container):  # pylint: disable=invali
 
     # Corrupt the object
     with open(
-        temp_container._get_pack_path_from_pack_id(str(meta["pack_id"])), "wb"
+        temp_container._get_pack_path_from_pack_id(str(meta['pack_id'])), 'wb'
     ) as fhandle:
         # Short corrupted string so also the size is wrong
-        fhandle.write(b"COR")
+        fhandle.write(b'COR')
 
     # I don't use the dataclass .is_valid() method of ValidationIssues because I want to
     # pop the error and check that there are no other issues but only the one I'm aware of
     errors = dataclasses.asdict(temp_container.validate())
-    problems = errors.pop("invalid_hashes_packed")
+    problems = errors.pop('invalid_hashes_packed')
     assert set(problems) == {hashkey1}
 
-    problems = errors.pop("invalid_sizes_packed")
+    problems = errors.pop('invalid_sizes_packed')
     assert set(problems) == {hashkey1}
 
     # There shouldn't be any other error
@@ -2399,12 +2388,12 @@ def test_validate_callback(temp_container, callback_instance):
     # Add packed objects (2001, 10 chars each), *not* a multiple of 400 (that is the internal value
     # of how many events should be triggered as a maximum)
     len_packed = 2001
-    data = [f"p{i:09d}".encode("ascii") for i in range(len_packed)]
+    data = [f'p{i:09d}'.encode('ascii') for i in range(len_packed)]
     temp_container.add_objects_to_pack(data)
 
     # Add loose objects (1x)
     len_loose = 101
-    data = [f"l{i:09d}".encode("ascii") for i in range(len_loose)]
+    data = [f'l{i:09d}'.encode('ascii') for i in range(len_loose)]
     for content in data:
         temp_container.add_object(content)
 
@@ -2416,29 +2405,29 @@ def test_validate_callback(temp_container, callback_instance):
 
     # I convert to dict because I the order of the actions can change
     performed_actions_dict = {
-        action["start_value"]["description"]: action
+        action['start_value']['description']: action
         for action in callback_instance.performed_actions
     }
 
     assert performed_actions_dict == {
-        "Loose objects": {
-            "start_value": {"total": len_loose, "description": "Loose objects"},
-            "value": len_loose,
+        'Loose objects': {
+            'start_value': {'total': len_loose, 'description': 'Loose objects'},
+            'value': len_loose,
         },
-        "Pack 0": {
-            "start_value": {"total": len_packed, "description": "Pack 0"},
-            "value": len_packed,
+        'Pack 0': {
+            'start_value': {'total': len_packed, 'description': 'Pack 0'},
+            'value': len_packed,
         },
     }
 
 
-@pytest.mark.parametrize("use_size_hint", [True, False])
+@pytest.mark.parametrize('use_size_hint', [True, False])
 def test_add_streamed_object_to_pack_callback(  # pylint: disable=invalid-name
     temp_container, use_size_hint, callback_instance
 ):
     """Test the correctness of the callback of add_streamed_object_to_pack."""
     length = 1000000
-    content = b"0" * length
+    content = b'0' * length
     stream = io.BytesIO(content)
 
     if use_size_hint:
@@ -2458,17 +2447,17 @@ def test_add_streamed_object_to_pack_callback(  # pylint: disable=invalid-name
 
     assert callback_instance.performed_actions == [
         {
-            "start_value": {
-                "total": length if use_size_hint else 0,
-                "description": "Streamed object",
+            'start_value': {
+                'total': length if use_size_hint else 0,
+                'description': 'Streamed object',
             },
-            "value": length,
+            'value': length,
         }
     ]
 
 
 @pytest.mark.parametrize(
-    "no_holes,no_holes_read_twice", [[True, True], [True, False], [False, False]]
+    'no_holes,no_holes_read_twice', [[True, True], [True, False], [False, False]]
 )
 def test_add_streamed_objects_to_pack_callback(  # pylint: disable=invalid-name
     temp_container, callback_instance, no_holes, no_holes_read_twice
@@ -2476,7 +2465,7 @@ def test_add_streamed_objects_to_pack_callback(  # pylint: disable=invalid-name
     """Test the correctness of the callback of add_streamed_objects_to_pack."""
     # Add packed objects (2001, 10 chars each)
     len_packed = 2001
-    stream_list = [io.BytesIO(f"p{i:09d}".encode("ascii")) for i in range(len_packed)]
+    stream_list = [io.BytesIO(f'p{i:09d}'.encode('ascii')) for i in range(len_packed)]
 
     temp_container.add_streamed_objects_to_pack(
         stream_list,
@@ -2487,7 +2476,7 @@ def test_add_streamed_objects_to_pack_callback(  # pylint: disable=invalid-name
 
     # Add another 4001 packed objects with 2001 already-existing objects
     len_packed2 = 4001
-    stream_list = [io.BytesIO(f"2p{i:09d}".encode("ascii")) for i in range(len_packed2)]
+    stream_list = [io.BytesIO(f'2p{i:09d}'.encode('ascii')) for i in range(len_packed2)]
 
     temp_container.add_streamed_objects_to_pack(
         stream_list,
@@ -2504,8 +2493,8 @@ def test_add_streamed_objects_to_pack_callback(  # pylint: disable=invalid-name
     # First call
     expected_actions.append(
         {
-            "start_value": {"total": len_packed, "description": "Bulk storing"},
-            "value": len_packed,
+            'start_value': {'total': len_packed, 'description': 'Bulk storing'},
+            'value': len_packed,
         }
     )
     # Second call
@@ -2513,14 +2502,14 @@ def test_add_streamed_objects_to_pack_callback(  # pylint: disable=invalid-name
         # If no_holes is True, i.e. we do not want holes, we compute an initial list of the existing ones
         expected_actions.append(
             {
-                "start_value": {"total": len_packed, "description": "List existing"},
-                "value": len_packed,
+                'start_value': {'total': len_packed, 'description': 'List existing'},
+                'value': len_packed,
             }
         )
     expected_actions.append(
         {
-            "start_value": {"total": len_packed2, "description": "Bulk storing"},
-            "value": len_packed2,
+            'start_value': {'total': len_packed2, 'description': 'Bulk storing'},
+            'value': len_packed2,
         }
     )
 
@@ -2528,14 +2517,14 @@ def test_add_streamed_objects_to_pack_callback(  # pylint: disable=invalid-name
 
 
 # Check both with the same hash type and with a different one
-@pytest.mark.parametrize("other_container_hash_type", ["sha256", "sha1"])
+@pytest.mark.parametrize('other_container_hash_type', ['sha256', 'sha1'])
 def test_import_objects_callback(
     temp_container, callback_instance, other_container_hash_type
 ):
     """Test the correctness of the callback of import_objects."""
     # Add packed objects (2001, 10 chars each)
     len_packed = 2001
-    stream_list = [io.BytesIO(f"p{i:09d}".encode("ascii")) for i in range(len_packed)]
+    stream_list = [io.BytesIO(f'p{i:09d}'.encode('ascii')) for i in range(len_packed)]
     hashkeys = temp_container.add_streamed_objects_to_pack(stream_list)
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -2549,12 +2538,12 @@ def test_import_objects_callback(
         )
 
         assert (
-            other_container.count_objects()["loose"]
-            == temp_container.count_objects()["loose"]
+            other_container.count_objects()['loose']
+            == temp_container.count_objects()['loose']
         )
         assert (
-            other_container.count_objects()["packed"]
-            == temp_container.count_objects()["packed"]
+            other_container.count_objects()['packed']
+            == temp_container.count_objects()['packed']
         )
 
         # close before exiting the context manager, so files are closed.
@@ -2564,40 +2553,38 @@ def test_import_objects_callback(
     if other_container_hash_type == temp_container.hash_type:
         expected_actions.append(
             {
-                "start_value": {"description": "Listing objects", "total": len_packed},
-                "value": len_packed,
+                'start_value': {'description': 'Listing objects', 'total': len_packed},
+                'value': len_packed,
             }
         )
     expected_actions.append(
         {
-            "start_value": {"description": "Copy objects", "total": len_packed},
-            "value": len_packed,
+            'start_value': {'description': 'Copy objects', 'total': len_packed},
+            'value': len_packed,
         }
     )
     # len_packed is small (and the objects are small)
     # so they all end up in the final flush
     expected_actions.append(
         {
-            "start_value": {"description": "Final flush", "total": len_packed},
-            "value": len_packed,
+            'start_value': {'description': 'Final flush', 'total': len_packed},
+            'value': len_packed,
         }
     )
 
     assert callback_instance.performed_actions == expected_actions
 
 
-@pytest.mark.parametrize("ask_deleting_unknown", [True, False])
-@pytest.mark.parametrize("compress", [True, False])
-def test_delete(
-    temp_container, compress, ask_deleting_unknown
-):  # pylint: disable=too-many-statements
+@pytest.mark.parametrize('ask_deleting_unknown', [True, False])
+@pytest.mark.parametrize('compress', [True, False])
+def test_delete(temp_container, compress, ask_deleting_unknown):  # pylint: disable=too-many-statements
     """Test the deletion logic."""
-    obj1 = b"324r3w"  # Will be packed (from loose)
-    obj2 = b"jklf2wv"  # Will be loose
-    obj3 = b"9z0vx0"  # Will be stored directly packed
+    obj1 = b'324r3w'  # Will be packed (from loose)
+    obj2 = b'jklf2wv'  # Will be loose
+    obj3 = b'9z0vx0'  # Will be stored directly packed
 
     unknown_hashkey = utils.get_hash_cls(temp_container.hash_type)(
-        b"NOT_EXISTING_OBJECT_CONTENT"
+        b'NOT_EXISTING_OBJECT_CONTENT'
     ).hexdigest()
 
     hashkey1 = temp_container.add_object(obj1)
@@ -2611,9 +2598,9 @@ def test_delete(
     assert temp_container._get_loose_path_from_hashkey(hashkey1).exists()
 
     # Assert the objects are of the expected type
-    assert temp_container.get_object_meta(hashkey1)["type"] == ObjectType.PACKED
-    assert temp_container.get_object_meta(hashkey2)["type"] == ObjectType.LOOSE
-    assert temp_container.get_object_meta(hashkey3)["type"] == ObjectType.PACKED
+    assert temp_container.get_object_meta(hashkey1)['type'] == ObjectType.PACKED
+    assert temp_container.get_object_meta(hashkey2)['type'] == ObjectType.LOOSE
+    assert temp_container.get_object_meta(hashkey3)['type'] == ObjectType.PACKED
     with pytest.raises(exc.NotExistent):
         temp_container.get_object_meta(unknown_hashkey)
 
@@ -2629,8 +2616,8 @@ def test_delete(
     # In any case, only one object should have been deleted
     assert list(deleted) == [hashkey3]
     # Assert the objects are of the expected type
-    assert temp_container.get_object_meta(hashkey1)["type"] == ObjectType.PACKED
-    assert temp_container.get_object_meta(hashkey2)["type"] == ObjectType.LOOSE
+    assert temp_container.get_object_meta(hashkey1)['type'] == ObjectType.PACKED
+    assert temp_container.get_object_meta(hashkey2)['type'] == ObjectType.LOOSE
     with pytest.raises(exc.NotExistent):
         temp_container.get_object_meta(hashkey3)
     with pytest.raises(exc.NotExistent):
@@ -2650,7 +2637,7 @@ def test_delete(
     # Assert the objects are of the expected type
     with pytest.raises(exc.NotExistent):
         temp_container.get_object_meta(hashkey1)
-    assert temp_container.get_object_meta(hashkey2)["type"] == ObjectType.LOOSE
+    assert temp_container.get_object_meta(hashkey2)['type'] == ObjectType.LOOSE
     with pytest.raises(exc.NotExistent):
         temp_container.get_object_meta(hashkey3)
     with pytest.raises(exc.NotExistent):
@@ -2684,21 +2671,21 @@ def test_delete(
 
 def test_delete_with_duplicates(temp_container):
     """Test the deletion logic."""
-    content = b"324r3w"
+    content = b'324r3w'
     hashkey = temp_container.add_object(content)
 
-    content2 = b"dsfsa"
+    content2 = b'dsfsa'
     # Add a second object
     hashkey2 = temp_container.add_object(content2)
 
     assert not os.listdir(temp_container._get_duplicates_folder())
 
-    with open(temp_container._get_loose_path_from_hashkey(hashkey), "wb") as fhandle:
+    with open(temp_container._get_loose_path_from_hashkey(hashkey), 'wb') as fhandle:
         # Write some corrupted content
-        fhandle.write(b"CORRUPTED")
-    with open(temp_container._get_loose_path_from_hashkey(hashkey2), "wb") as fhandle:
+        fhandle.write(b'CORRUPTED')
+    with open(temp_container._get_loose_path_from_hashkey(hashkey2), 'wb') as fhandle:
         # Write some corrupted content
-        fhandle.write(b"CORRUPTED")
+        fhandle.write(b'CORRUPTED')
 
     # I should get the corrupted content
     assert temp_container.get_object_content(hashkey) != content
@@ -2757,10 +2744,10 @@ def test_delete_with_duplicates(temp_container):
     )
 
     # Also put back the correct content - this was just to trigger the creation of a duplicate
-    with open(temp_container._get_loose_path_from_hashkey(hashkey), "wb") as fhandle:
+    with open(temp_container._get_loose_path_from_hashkey(hashkey), 'wb') as fhandle:
         # Write some corrupted content
         fhandle.write(content)
-    with open(temp_container._get_loose_path_from_hashkey(hashkey2), "wb") as fhandle:
+    with open(temp_container._get_loose_path_from_hashkey(hashkey2), 'wb') as fhandle:
         # Write some corrupted content
         fhandle.write(content2)
     assert temp_container.get_object_content(hashkey) == content
@@ -2780,7 +2767,7 @@ def test_delete_with_duplicates(temp_container):
     assert len(duplicates) == 1
     # The only duplicate left should be for the second object
     duplicate = duplicates[0]
-    assert duplicate.startswith(f"{hashkey2}.")
+    assert duplicate.startswith(f'{hashkey2}.')
 
     # I delete also the second object: also those files should go away
     temp_container.delete_objects([hashkey2])
@@ -2795,28 +2782,28 @@ def test_clean_storage_with_duplicates(
 ):  # pylint: disable=too-many-statements, invalid-name
     """Check the logic when using the clean storage method and where there are duplicates."""
     duplicates_folder = temp_container._get_duplicates_folder()
-    content1 = b"324r3w"
+    content1 = b'324r3w'
     hashkey1 = temp_container.add_object(content1)
 
-    content2 = b"dsfsa"
+    content2 = b'dsfsa'
     # Add a second object
     hashkey2 = temp_container.add_object(content2)
 
-    content3 = b"wejvlweekf"
+    content3 = b'wejvlweekf'
     # Add a second object
     hashkey3 = temp_container.add_object(content3)
 
     assert not os.listdir(duplicates_folder)
 
-    with open(temp_container._get_loose_path_from_hashkey(hashkey1), "wb") as fhandle:
+    with open(temp_container._get_loose_path_from_hashkey(hashkey1), 'wb') as fhandle:
         # Write some corrupted content
-        fhandle.write(b"CORRUPTED")
-    with open(temp_container._get_loose_path_from_hashkey(hashkey2), "wb") as fhandle:
+        fhandle.write(b'CORRUPTED')
+    with open(temp_container._get_loose_path_from_hashkey(hashkey2), 'wb') as fhandle:
         # Write some corrupted content
-        fhandle.write(b"CORRUPTED")
-    with open(temp_container._get_loose_path_from_hashkey(hashkey3), "wb") as fhandle:
+        fhandle.write(b'CORRUPTED')
+    with open(temp_container._get_loose_path_from_hashkey(hashkey3), 'wb') as fhandle:
         # Write some corrupted content
-        fhandle.write(b"CORRUPTED")
+        fhandle.write(b'CORRUPTED')
 
     # I should get the corrupted content
     assert temp_container.get_object_content(hashkey1) != content1
@@ -2906,10 +2893,10 @@ def test_clean_storage_with_duplicates(
     # - for the third object I leave the corrupted object, and corrupt all duplicates but one: the correct
     #   object should be restored, not duplicates should be left behind
     # Also put back the correct content - this was just to trigger the creation of a duplicate
-    with open(temp_container._get_loose_path_from_hashkey(hashkey1), "wb") as fhandle:
+    with open(temp_container._get_loose_path_from_hashkey(hashkey1), 'wb') as fhandle:
         # Write back correct content
         fhandle.write(content1)
-    with open(temp_container._get_loose_path_from_hashkey(hashkey2), "wb") as fhandle:
+    with open(temp_container._get_loose_path_from_hashkey(hashkey2), 'wb') as fhandle:
         # Write back correct content
         fhandle.write(content2)
     assert temp_container.get_object_content(hashkey1) == content1
@@ -2918,17 +2905,17 @@ def test_clean_storage_with_duplicates(
 
     hash3_corrupt_count = 0
     for duplicate in os.listdir(duplicates_folder):
-        if duplicate.startswith(f"{hashkey2}."):
+        if duplicate.startswith(f'{hashkey2}.'):
             # All duplicates of object 2 are corrupt
-            with open(duplicates_folder / duplicate, "wb") as fhandle:
-                fhandle.write(b"CORRUPT")
+            with open(duplicates_folder / duplicate, 'wb') as fhandle:
+                fhandle.write(b'CORRUPT')
 
-        if duplicate.startswith(f"{hashkey3}."):
+        if duplicate.startswith(f'{hashkey3}.'):
             hash3_corrupt_count += 1
             if hash3_corrupt_count <= 2:
                 # I corrupt 2 out of three duplicates of object three
-                with open(duplicates_folder / duplicate, "wb") as fhandle:
-                    fhandle.write(b"CORRUPT")
+                with open(duplicates_folder / duplicate, 'wb') as fhandle:
+                    fhandle.write(b'CORRUPT')
 
     # No exception here
     temp_container.clean_storage()
@@ -2952,14 +2939,14 @@ def test_clean_storage_with_duplicates_all_corrupt(
     """Check the logic when using the clean storage method and where there are duplicates,
     and object and all duplicates are corrupt."""
     duplicates_folder = temp_container._get_duplicates_folder()
-    content1 = b"324r3w"
+    content1 = b'324r3w'
     hashkey1 = temp_container.add_object(content1)
 
     assert not os.listdir(duplicates_folder)
 
-    with open(temp_container._get_loose_path_from_hashkey(hashkey1), "wb") as fhandle:
+    with open(temp_container._get_loose_path_from_hashkey(hashkey1), 'wb') as fhandle:
         # Write some corrupted content
-        fhandle.write(b"CORRUPTED")
+        fhandle.write(b'CORRUPTED')
 
     # I should get the corrupted content
     assert temp_container.get_object_content(hashkey1) != content1
@@ -3002,14 +2989,14 @@ def test_clean_storage_with_duplicates_all_corrupt(
     # - I leave the object corrupted, and I corrupt *ALL* duplicates
 
     for duplicate in os.listdir(duplicates_folder):
-        assert duplicate.startswith(f"{hashkey1}.")  # Just to check the behavior
-        with open(duplicates_folder / duplicate, "wb") as fhandle:
-            fhandle.write(b"CORRUPT")
+        assert duplicate.startswith(f'{hashkey1}.')  # Just to check the behavior
+        with open(duplicates_folder / duplicate, 'wb') as fhandle:
+            fhandle.write(b'CORRUPT')
 
     # I check that I get an error because everything is inconsistent
     with pytest.raises(exc.InconsistentContent) as excinfo:
         temp_container.clean_storage()
-    assert "all corrupt" in str(excinfo.value)
+    assert 'all corrupt' in str(excinfo.value)
 
 
 def test_clean_storage_with_duplicates_original_deleted(
@@ -3017,14 +3004,14 @@ def test_clean_storage_with_duplicates_original_deleted(
 ):  # pylint: disable=invalid-name
     """Check the logic when using the clean storage method and where there are duplicates."""
     duplicates_folder = temp_container._get_duplicates_folder()
-    content1 = b"324r3w"
+    content1 = b'324r3w'
     hashkey1 = temp_container.add_object(content1)
 
     assert not os.listdir(duplicates_folder)
 
-    with open(temp_container._get_loose_path_from_hashkey(hashkey1), "wb") as fhandle:
+    with open(temp_container._get_loose_path_from_hashkey(hashkey1), 'wb') as fhandle:
         # Write some corrupted content
-        fhandle.write(b"CORRUPTED")
+        fhandle.write(b'CORRUPTED')
 
     # I should get the corrupted content
     assert temp_container.get_object_content(hashkey1) != content1
@@ -3070,7 +3057,7 @@ def test_clean_storage_with_duplicates_original_deleted(
     # I check that I get an error because the original is not there but there are duplicates
     with pytest.raises(exc.InconsistentContent) as excinfo:
         temp_container.clean_storage()
-    assert "does not exist anymore" in str(excinfo.value)
+    assert 'does not exist anymore' in str(excinfo.value)
 
     # Deleting the object should be enough to clean up the issue
     temp_container.delete_objects([hashkey1])
@@ -3084,17 +3071,17 @@ def test_clean_storage_with_duplicates_original_deleted(
 
 
 @pytest.mark.parametrize(
-    "no_holes, no_holes_read_twice", [[True, True], [True, False], [False, True]]
+    'no_holes, no_holes_read_twice', [[True, True], [True, False], [False, True]]
 )
-@pytest.mark.parametrize("use_streams", [True, False])
-@pytest.mark.parametrize("compress", [True, False])
+@pytest.mark.parametrize('use_streams', [True, False])
+@pytest.mark.parametrize('compress', [True, False])
 def test_packs_no_holes(
     temp_container, no_holes, no_holes_read_twice, use_streams, compress, monkeypatch
 ):
     """Test what happens when writing directly to packs and asking not to leave back holes."""
-    content1 = b"1234567"
-    content2 = b"wefvmafsf"
-    content3 = b"224f"
+    content1 = b'1234567'
+    content2 = b'wefvmafsf'
+    content3 = b'224f'
 
     hashkey1 = utils.get_hash_cls(temp_container.hash_type)(content1).hexdigest()
     hashkey2 = utils.get_hash_cls(temp_container.hash_type)(content2).hexdigest()
@@ -3125,18 +3112,18 @@ def test_packs_no_holes(
     assert set(temp_container.list_all_objects()) == set(hashkeys)
 
     sizes = temp_container.get_total_size()
-    assert sizes["total_size_packed"] == len(content1) + len(content2) + len(content3)
+    assert sizes['total_size_packed'] == len(content1) + len(content2) + len(content3)
 
     if no_holes:
         assert (
-            sizes["total_size_packed_on_disk"] == sizes["total_size_packfiles_on_disk"]
+            sizes['total_size_packed_on_disk'] == sizes['total_size_packfiles_on_disk']
         )
     else:
         # We have added twice each object. Note: we cannot use total_size_packed because this would be
         # before compression
         assert (
-            2 * sizes["total_size_packed_on_disk"]
-            == sizes["total_size_packfiles_on_disk"]
+            2 * sizes['total_size_packed_on_disk']
+            == sizes['total_size_packfiles_on_disk']
         )
 
     # Add again the same objects, in a new call
@@ -3157,7 +3144,7 @@ def test_packs_no_holes(
     temp_container._tmp_write_to_packfile = temp_container._write_data_to_packfile
     monkeypatch.setattr(
         temp_container,
-        "_write_data_to_packfile",
+        '_write_data_to_packfile',
         functools.partial(
             new_write_data_to_packfile, self=temp_container, call_counter=call_counter
         ),
@@ -3191,28 +3178,28 @@ def test_packs_no_holes(
 
     new_sizes = temp_container.get_total_size()
     # No new objects, so same size
-    assert new_sizes["total_size_packed"] == len(content1) + len(content2) + len(
+    assert new_sizes['total_size_packed'] == len(content1) + len(content2) + len(
         content3
     )
 
     if no_holes:
         # Shouldn't have created more space on disk
         assert (
-            new_sizes["total_size_packed_on_disk"] == sizes["total_size_packed_on_disk"]
+            new_sizes['total_size_packed_on_disk'] == sizes['total_size_packed_on_disk']
         )
         assert (
-            new_sizes["total_size_packfiles_on_disk"]
-            == sizes["total_size_packfiles_on_disk"]
+            new_sizes['total_size_packfiles_on_disk']
+            == sizes['total_size_packfiles_on_disk']
         )
     else:
         # We have doubled the space on disk
         assert (
-            new_sizes["total_size_packfiles_on_disk"]
-            == 2 * sizes["total_size_packfiles_on_disk"]
+            new_sizes['total_size_packfiles_on_disk']
+            == 2 * sizes['total_size_packfiles_on_disk']
         )
         # (but shouldn't have increased the size of packed objects on disk)
         assert (
-            new_sizes["total_size_packed_on_disk"] == sizes["total_size_packed_on_disk"]
+            new_sizes['total_size_packed_on_disk'] == sizes['total_size_packed_on_disk']
         )
 
 
@@ -3237,7 +3224,7 @@ def test_packs_read_in_order(temp_dir):
     # A apck should accomodate ~100 objects, and there should be > 90 packs
     temp_container.init_container(clear=True, pack_size_target=100000)
 
-    data = [(f"{i}-".encode("ascii") * obj_size)[:obj_size] for i in range(num_objects)]
+    data = [(f'{i}-'.encode('ascii') * obj_size)[:obj_size] for i in range(num_objects)]
     hashkeys = temp_container.add_objects_to_pack(data, compress=False)
 
     # Check that I indeed created num_objects (different) objects
@@ -3255,27 +3242,27 @@ def test_packs_read_in_order(temp_dir):
         hashkeys, skip_if_missing=False
     ) as triplets:
         for _, _, meta in triplets:  # pylint: disable=not-an-iterable
-            assert meta["type"] == ObjectType.PACKED
+            assert meta['type'] == ObjectType.PACKED
             if last_pack is None:
-                last_pack = meta["pack_id"]
-                seen_packs.add(meta["pack_id"])
+                last_pack = meta['pack_id']
+                seen_packs.add(meta['pack_id'])
                 last_offset = 0
-            elif meta["pack_id"] != last_pack:
-                assert meta["pack_id"] not in seen_packs, (
+            elif meta['pack_id'] != last_pack:
+                assert meta['pack_id'] not in seen_packs, (
                     f"Objects were already retrieved from pack {meta['pack_id']}, "
                     f"the last pack was {last_pack} "
                     f"and we are trying to retrieve again from pack {meta['pack_id']}"
                 )
-                last_pack = meta["pack_id"]
-                seen_packs.add(meta["pack_id"])
+                last_pack = meta['pack_id']
+                seen_packs.add(meta['pack_id'])
                 last_offset = 0
             # We are still in the same pack
-            assert last_offset <= meta["pack_offset"], (
+            assert last_offset <= meta['pack_offset'], (
                 f"in pack {meta['pack_id']} we are reading offset "
                 f"{meta['pack_offset']}, but before we were reading "
                 f"a later offset {last_offset}"
             )
-            last_offset = meta["pack_offset"]
+            last_offset = meta['pack_offset']
 
     # I want to make sure to have generated enough packs, meaning this function is actually testing the behavior
     # This should generated 90 packs
@@ -3291,7 +3278,7 @@ def test_packs_read_in_order(temp_dir):
     temp_container.close()
 
 
-@pytest.mark.parametrize("compress_mode", list(CompressMode))
+@pytest.mark.parametrize('compress_mode', list(CompressMode))
 def test_repack(temp_dir, compress_mode):
     """Test the repacking functionality."""
     temp_container = Container(temp_dir)
@@ -3299,15 +3286,15 @@ def test_repack(temp_dir, compress_mode):
 
     # data of 10 bytes each. Will fill two packs.
     data = [
-        b"-123456789",
-        b"a123456789",
-        b"b123456789",
-        b"c123456789",
-        b"d123456789",
-        b"e123456789",
-        b"f123456789",
-        b"g123456789",
-        b"h123456789",
+        b'-123456789',
+        b'a123456789',
+        b'b123456789',
+        b'c123456789',
+        b'd123456789',
+        b'e123456789',
+        b'f123456789',
+        b'g123456789',
+        b'h123456789',
     ]
 
     hashkeys = []
@@ -3315,28 +3302,28 @@ def test_repack(temp_dir, compress_mode):
     for datum in data:
         hashkeys.append(temp_container.add_objects_to_pack([datum])[0])
 
-    assert temp_container.get_object_meta(hashkeys[0])["pack_id"] == 0
-    assert temp_container.get_object_meta(hashkeys[1])["pack_id"] == 0
-    assert temp_container.get_object_meta(hashkeys[2])["pack_id"] == 0
-    assert temp_container.get_object_meta(hashkeys[3])["pack_id"] == 0
-    assert temp_container.get_object_meta(hashkeys[4])["pack_id"] == 1
-    assert temp_container.get_object_meta(hashkeys[5])["pack_id"] == 1
-    assert temp_container.get_object_meta(hashkeys[6])["pack_id"] == 1
-    assert temp_container.get_object_meta(hashkeys[7])["pack_id"] == 1
-    assert temp_container.get_object_meta(hashkeys[8])["pack_id"] == 2
+    assert temp_container.get_object_meta(hashkeys[0])['pack_id'] == 0
+    assert temp_container.get_object_meta(hashkeys[1])['pack_id'] == 0
+    assert temp_container.get_object_meta(hashkeys[2])['pack_id'] == 0
+    assert temp_container.get_object_meta(hashkeys[3])['pack_id'] == 0
+    assert temp_container.get_object_meta(hashkeys[4])['pack_id'] == 1
+    assert temp_container.get_object_meta(hashkeys[5])['pack_id'] == 1
+    assert temp_container.get_object_meta(hashkeys[6])['pack_id'] == 1
+    assert temp_container.get_object_meta(hashkeys[7])['pack_id'] == 1
+    assert temp_container.get_object_meta(hashkeys[8])['pack_id'] == 2
 
     # I check which packs exist
     assert sorted(temp_container._list_packs()) == [
-        "0",
-        "1",
-        "2",
+        '0',
+        '1',
+        '2',
     ]
 
     counts = temp_container.count_objects()
-    assert counts["packed"] == len(data)
+    assert counts['packed'] == len(data)
     size = temp_container.get_total_size()
-    assert size["total_size_packed"] == 10 * len(data)
-    assert size["total_size_packfiles_on_disk"] == 10 * len(data)
+    assert size['total_size_packed'] == 10 * len(data)
+    assert size['total_size_packfiles_on_disk'] == 10 * len(data)
 
     # I delete an object in the middle, an object at the end of a pack, and an object at the beginning.
     # I also delete the only object
@@ -3346,40 +3333,40 @@ def test_repack(temp_dir, compress_mode):
 
     # I check that all packs are still there
     assert sorted(temp_container._list_packs()) == [
-        "0",
-        "1",
-        "2",
+        '0',
+        '1',
+        '2',
     ]
 
     counts = temp_container.count_objects()
-    assert counts["packed"] == len(data) - len(to_delete)
+    assert counts['packed'] == len(data) - len(to_delete)
     size = temp_container.get_total_size()
     # I deleted 4 objects
-    assert size["total_size_packed"] == 10 * (len(data) - len(to_delete))
+    assert size['total_size_packed'] == 10 * (len(data) - len(to_delete))
     # Still full size on disk
-    assert size["total_size_packfiles_on_disk"] == 10 * len(data)
+    assert size['total_size_packfiles_on_disk'] == 10 * len(data)
 
     # I now repack
     temp_container.repack(compress_mode=compress_mode)
 
     # I check that all packs are still there, but pack 2 was deleted
     assert sorted(temp_container._list_packs()) == [
-        "0",
-        "1",
+        '0',
+        '1',
     ]
 
     counts = temp_container.count_objects()
-    assert counts["packed"] == len(data) - len(to_delete)
+    assert counts['packed'] == len(data) - len(to_delete)
     size = temp_container.get_total_size()
-    assert size["total_size_packed"] == 10 * (len(data) - len(to_delete))
+    assert size['total_size_packed'] == 10 * (len(data) - len(to_delete))
     # This time also the size on disk should be adapted (it's the main goal of repacking)
     objects_meta = dict(
         temp_container.get_objects_meta(
             [hashkeys[idx] for idx in range(len(hashkeys)) if idx not in idx_to_delete]
         )
     )
-    assert size["total_size_packfiles_on_disk"] == sum(
-        list(meta["pack_length"] for meta in objects_meta.values())
+    assert size['total_size_packfiles_on_disk'] == sum(
+        list(meta['pack_length'] for meta in objects_meta.values())
     )
 
     # Check that the content is still correct
@@ -3391,9 +3378,9 @@ def test_repack(temp_dir, compress_mode):
     temp_container.close()
 
 
-@pytest.mark.parametrize("repack_compress_mode", list(CompressMode))
-@pytest.mark.parametrize("compress_pack", [True, False])
-@pytest.mark.parametrize("small_size", [True, False])
+@pytest.mark.parametrize('repack_compress_mode', list(CompressMode))
+@pytest.mark.parametrize('compress_pack', [True, False])
+@pytest.mark.parametrize('small_size', [True, False])
 def test_repack_compress_modes(
     temp_container: Container, small_size, compress_pack, repack_compress_mode
 ):
@@ -3401,7 +3388,7 @@ def test_repack_compress_modes(
 
     # Write 10*1_000_000 = 10 million bytes, larger than a chunk
     # this should be quite compressible even with the heuristics
-    content_compr = b"0123456789" * 100
+    content_compr = b'0123456789' * 100
     if not small_size:
         content_compr *= 10_000
     # This instead is 10 million random bytes, probably uncompressible
@@ -3416,11 +3403,11 @@ def test_repack_compress_modes(
     temp_container.pack_all_loose(compress=compress_pack)
     # Both should have the expected compression mode from the variable `compress_mode`
     assert (
-        temp_container.get_object_meta(hashkey_compr)["pack_compressed"]
+        temp_container.get_object_meta(hashkey_compr)['pack_compressed']
         == compress_pack
     )
     assert (
-        temp_container.get_object_meta(hashkey_uncompr)["pack_compressed"]
+        temp_container.get_object_meta(hashkey_uncompr)['pack_compressed']
         == compress_pack
     )
 
@@ -3434,35 +3421,35 @@ def test_repack_compress_modes(
     # We now check the expected compression mode
     if repack_compress_mode == CompressMode.NO:
         # All should be uncompressed
-        assert temp_container.get_object_meta(hashkey_compr)["pack_compressed"] is False
+        assert temp_container.get_object_meta(hashkey_compr)['pack_compressed'] is False
         assert (
-            temp_container.get_object_meta(hashkey_uncompr)["pack_compressed"] is False
+            temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is False
         )
     elif repack_compress_mode == CompressMode.YES:
         # All should be compressed
-        assert temp_container.get_object_meta(hashkey_compr)["pack_compressed"] is True
+        assert temp_container.get_object_meta(hashkey_compr)['pack_compressed'] is True
         assert (
-            temp_container.get_object_meta(hashkey_uncompr)["pack_compressed"] is True
+            temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is True
         )
     elif repack_compress_mode == CompressMode.KEEP:
         # Should not have changed
         assert (
-            temp_container.get_object_meta(hashkey_compr)["pack_compressed"]
+            temp_container.get_object_meta(hashkey_compr)['pack_compressed']
             == compress_pack
         )
         assert (
-            temp_container.get_object_meta(hashkey_uncompr)["pack_compressed"]
+            temp_container.get_object_meta(hashkey_uncompr)['pack_compressed']
             == compress_pack
         )
     elif repack_compress_mode == CompressMode.AUTO:
         # Only really compressible streams should be compressed
-        assert temp_container.get_object_meta(hashkey_compr)["pack_compressed"] is True
+        assert temp_container.get_object_meta(hashkey_compr)['pack_compressed'] is True
         assert (
-            temp_container.get_object_meta(hashkey_uncompr)["pack_compressed"] is False
+            temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is False
         )
     else:
         raise AssertionError(
-            f"Unknown {repack_compress_mode=}, most probably you added a new CompressMode and need to update the tests"
+            f'Unknown {repack_compress_mode=}, most probably you added a new CompressMode and need to update the tests'
         )
 
     # Try to repack to non-compressed, then to compressed, then again to this mode,
@@ -3480,18 +3467,18 @@ def test_repack_compress_modes(
     assert issues.is_valid()
 
 
-@pytest.mark.parametrize("start_compressed", [True, False])
+@pytest.mark.parametrize('start_compressed', [True, False])
 def test_repack_auto_many_sizes(temp_container: Container, start_compressed):
     """Check repack()+CompressMode.AUTO with various object sizes."""
 
     objects = []
     for length in range(0, 10_000):
         # All possible small lengths up to 10_000
-        objects.append(b"a" * length)
+        objects.append(b'a' * length)
     # A few larger lengths - otherwise it takes ages to create all
     # in memory and compress them!
     for length in range(10_001, 10_000_000, 300_000):
-        objects.append(b"a" * length)
+        objects.append(b'a' * length)
     temp_container.add_objects_to_pack(objects, compress=start_compressed)
 
     # We now repack, and check if everything is correct
@@ -3504,7 +3491,7 @@ def test_repack_progress_bar(temp_container: Container):
     """Check that the progress bar is correctly updated when packing all loose objects."""
     objects = []
     for length in range(0, 100):
-        objects.append(b"a" * length)
+        objects.append(b'a' * length)
 
     temp_container.add_objects_to_pack(objects, compress=False)
 
@@ -3513,24 +3500,24 @@ def test_repack_progress_bar(temp_container: Container):
 
     def progress(action, value):
         """A dummy progress function."""
-        if action == "init":
+        if action == 'init':
             assert (
-                value["total"] == temp_container.get_total_size()["total_size_packed"]
+                value['total'] == temp_container.get_total_size()['total_size_packed']
             )
             nonlocal passed_total
-            passed_total = value["total"]
-            assert value["description"] == "Repack 0"
-        elif action == "update":
+            passed_total = value['total']
+            assert value['description'] == 'Repack 0'
+        elif action == 'update':
             isinstance(value, (int, float))
             nonlocal passed_updates
             passed_updates += value
-        elif action == "close":
+        elif action == 'close':
             assert passed_updates == passed_total
 
     temp_container.repack(callback=progress)
 
 
-@pytest.mark.parametrize("compress_mode", [True, False] + list(CompressMode))
+@pytest.mark.parametrize('compress_mode', [True, False] + list(CompressMode))
 def test_pack_all_loose_compress_modes(temp_container: Container, compress_mode):
     """Check that pack_all_loose() uses the correct compression mode.
 
@@ -3538,7 +3525,7 @@ def test_pack_all_loose_compress_modes(temp_container: Container, compress_mode)
     """
     # Write 10*1_000_000 = 10 million bytes, larger than a chunk
     # this should be quite compressible even with the heuristics
-    content_compr = b"0123456789" * 1_000_000
+    content_compr = b'0123456789' * 1_000_000
     # This instead is 10 million random bytes, probably uncompressible
     content_uncompr = os.urandom(10_000_000)
 
@@ -3554,31 +3541,31 @@ def test_pack_all_loose_compress_modes(temp_container: Container, compress_mode)
     # We now check the expected compression mode
     if compress_mode == CompressMode.NO or compress_mode is False:
         # All should be uncompressed
-        assert temp_container.get_object_meta(hashkey_compr)["pack_compressed"] is False
+        assert temp_container.get_object_meta(hashkey_compr)['pack_compressed'] is False
         assert (
-            temp_container.get_object_meta(hashkey_uncompr)["pack_compressed"] is False
+            temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is False
         )
     elif compress_mode == CompressMode.YES or compress_mode is True:
         # All should be compressed
-        assert temp_container.get_object_meta(hashkey_compr)["pack_compressed"] is True
+        assert temp_container.get_object_meta(hashkey_compr)['pack_compressed'] is True
         assert (
-            temp_container.get_object_meta(hashkey_uncompr)["pack_compressed"] is True
+            temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is True
         )
     elif compress_mode == CompressMode.KEEP:
         # Should not have changed - so it should be False since loose objects are always uncompressed
-        assert temp_container.get_object_meta(hashkey_compr)["pack_compressed"] is False
+        assert temp_container.get_object_meta(hashkey_compr)['pack_compressed'] is False
         assert (
-            temp_container.get_object_meta(hashkey_uncompr)["pack_compressed"] is False
+            temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is False
         )
     elif compress_mode == CompressMode.AUTO:
         # Only really compressible streams should be compressed
-        assert temp_container.get_object_meta(hashkey_compr)["pack_compressed"] is True
+        assert temp_container.get_object_meta(hashkey_compr)['pack_compressed'] is True
         assert (
-            temp_container.get_object_meta(hashkey_uncompr)["pack_compressed"] is False
+            temp_container.get_object_meta(hashkey_uncompr)['pack_compressed'] is False
         )
     else:
         raise AssertionError(
-            f"Unknown {compress_mode=}, most probably you added a new CompressMode and need to update the tests"
+            f'Unknown {compress_mode=}, most probably you added a new CompressMode and need to update the tests'
         )
 
 
@@ -3586,7 +3573,7 @@ def test_pack_all_loose_many(temp_container):
     """Check the pack_all_loose when there are many objects to pack, more than _MAX_CHUNK_ITERATE_LENGTH."""
     expected = {}
     for idx in range(temp_container._MAX_CHUNK_ITERATE_LENGTH + 10):
-        content = f"{idx}".encode()
+        content = f'{idx}'.encode()
         expected[temp_container.add_object(content)] = content
 
     # Pack all loose objects
@@ -3606,7 +3593,7 @@ def test_pack_all_loose_progress_bar(temp_container):
     """Check that the progress bar is correctly updated when packing all loose objects."""
     # Add 10 objects
     for idx in range(10):
-        content = f"{idx}".encode()
+        content = f'{idx}'.encode()
         temp_container.add_object(content)
 
     passed_updates = 0
@@ -3614,16 +3601,16 @@ def test_pack_all_loose_progress_bar(temp_container):
 
     def progress(action, value):
         """A dummy progress function."""
-        if action == "init":
-            assert value["total"] == temp_container.get_total_size()["total_size_loose"]
+        if action == 'init':
+            assert value['total'] == temp_container.get_total_size()['total_size_loose']
             nonlocal passed_total
-            passed_total = value["total"]
-            assert value["description"] == "Packing loose objects"
-        elif action == "update":
+            passed_total = value['total']
+            assert value['description'] == 'Packing loose objects'
+        elif action == 'update':
             isinstance(value, (int, float))
             nonlocal passed_updates
             passed_updates += value
-        elif action == "close":
+        elif action == 'close':
             assert passed_updates == passed_total
 
     temp_container.pack_all_loose(callback=progress)
@@ -3641,14 +3628,14 @@ def test_container_id(temp_container):
 
 
 @pytest.mark.parametrize(
-    "compression_algorithm",
+    'compression_algorithm',
     [
-        "gzip",  # unknown
-        "zlib",  # no variant
-        "zlib+a",
-        "zlib+-1",
-        "zlib+10",
-        "unknown-method",  # Invalid variant
+        'gzip',  # unknown
+        'zlib',  # no variant
+        'zlib+a',
+        'zlib+-1',
+        'zlib+10',
+        'unknown-method',  # Invalid variant
     ],
 )
 def test_unknown_compressers(temp_container, compression_algorithm):
@@ -3663,9 +3650,9 @@ def test_unknown_compressers(temp_container, compression_algorithm):
 ## it really needs a Container to be functional.
 def test_lazy_loose_stream(temp_container):
     """Basic tests of the methods of a LazyLooseStream."""
-    content = b"b123456789"
+    content = b'b123456789'
 
-    temp_container.init_container(clear=True, compression_algorithm="zlib+9")
+    temp_container.init_container(clear=True, compression_algorithm='zlib+9')
     hashkey = temp_container.add_object(content)
 
     temp_container.pack_all_loose(compress=True)
@@ -3675,11 +3662,11 @@ def test_lazy_loose_stream(temp_container):
     assert not loosepath.exists()
     # Check that it's in a pack and it's compressed
     meta = temp_container.get_object_meta(hashkey)
-    assert meta["type"] == ObjectType.PACKED
-    assert meta["pack_compressed"]
+    assert meta['type'] == ObjectType.PACKED
+    assert meta['pack_compressed']
 
     lazy_loose = temp_container.get_lazy_loose_stream(hashkey=hashkey)
-    assert lazy_loose.mode == "rb"
+    assert lazy_loose.mode == 'rb'
     assert lazy_loose.seekable()
     with pytest.raises(ValueError):
         # Shouldn't be allowed to work on a non-open stream
@@ -3744,13 +3731,13 @@ def test_lazy_loose_stream(temp_container):
 
 def test_lazy_loose_stream_missing(temp_container):
     """Test behaviour of LazyLooseStream of a non-existing hashkey."""
-    temp_container.init_container(clear=True, compression_algorithm="zlib+9")
-    content = b"b123456789"
+    temp_container.init_container(clear=True, compression_algorithm='zlib+9')
+    content = b'b123456789'
     # It is loose, not packed
     hashkey = temp_container.add_object(content)
 
     # Try with a missing/wrong hashkey
-    missing_lazy = temp_container.get_lazy_loose_stream(hashkey="WRONGHASHKEY")
+    missing_lazy = temp_container.get_lazy_loose_stream(hashkey='WRONGHASHKEY')
     # Note: error is delayed to the opening of the stream
     with pytest.raises(exc.NotExistent):
         missing_lazy.open_stream()
@@ -3770,9 +3757,9 @@ def test_lazy_loose_stream_missing(temp_container):
 
 def test_lazy_loose_stream_context_man(temp_container):
     """Basic tests of the methods of a LazyLooseStream."""
-    content = b"b123456789"
+    content = b'b123456789'
 
-    temp_container.init_container(clear=True, compression_algorithm="zlib+9")
+    temp_container.init_container(clear=True, compression_algorithm='zlib+9')
     hashkey = temp_container.add_object(content)
 
     temp_container.pack_all_loose(compress=True)
@@ -3797,7 +3784,7 @@ def test_lazy_loose_stream_context_man(temp_container):
     assert lazy_loose.closed
 
 
-@pytest.mark.parametrize("num_iterations_delete", [3, 10])
+@pytest.mark.parametrize('num_iterations_delete', [3, 10])
 def test_lazy_loose_loosen_and_delete(
     temp_container, num_iterations_delete, monkeypatch
 ):
@@ -3806,7 +3793,7 @@ def test_lazy_loose_loosen_and_delete(
 
     This also ensures to test that specific code path.
     """
-    content = b"b123456789"
+    content = b'b123456789'
     hashkey = temp_container.add_object(content)
 
     temp_container.pack_all_loose(compress=True)
@@ -3821,7 +3808,7 @@ def test_lazy_loose_loosen_and_delete(
     def new_loosen_object(hashkey):
         """Pass to the original call"""
         self = temp_container
-        if hasattr(self, "call_counter"):
+        if hasattr(self, 'call_counter'):
             self.call_counter += 1
         else:
             self.call_counter = 1
@@ -3838,7 +3825,7 @@ def test_lazy_loose_loosen_and_delete(
         return retval
 
     Container._old_loosen_object = Container.loosen_object
-    monkeypatch.setattr(temp_container, "loosen_object", new_loosen_object)
+    monkeypatch.setattr(temp_container, 'loosen_object', new_loosen_object)
 
     if num_iterations_delete < 5:  # for the case of 3 it should work
         # this should work
@@ -3848,4 +3835,4 @@ def test_lazy_loose_loosen_and_delete(
     else:  # for the case of 10 it should fail as it's more than the MAX_RETRIES
         with pytest.raises(RuntimeError) as excinfo:
             lazy_loose.open_stream()
-        assert "Unable to open the loose object" in str(excinfo.value)
+        assert 'Unable to open the loose object' in str(excinfo.value)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -44,9 +44,7 @@ def test_example_objectstore(temp_dir, idx_and_options):
         if tempfile_idx is not None:
             options[tempfile_idx] = tmpfile.name
         script = EXAMPLES_DIR / 'example_objectstore.py'
-        output = subprocess.check_output(
-            [sys.executable, script, '-p', str(temp_dir / str(idx))] + options
-        )
+        output = subprocess.check_output([sys.executable, script, '-p', str(temp_dir / str(idx))] + options)
         assert output != ''
 
 
@@ -68,7 +66,5 @@ def test_example_profile_zeros(temp_dir, idx_and_options):
     """Test the example/profiling script 'profile_zeros'."""
     idx, options = idx_and_options
     script = EXAMPLES_DIR / 'profile_zeros.py'
-    output = subprocess.check_output(
-        [sys.executable, str(script), '-p', str(temp_dir / str(idx))] + options
-    )
+    output = subprocess.check_output([sys.executable, str(script), '-p', str(temp_dir / str(idx))] + options)
     assert output != ''

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,4 +1,5 @@
 """Test of the object-store container module."""
+
 import subprocess
 import sys
 import tempfile
@@ -10,20 +11,20 @@ import disk_objectstore
 from disk_objectstore.utils import nullcontext
 
 MODULE_DIR = Path(disk_objectstore.__file__).parent
-EXAMPLES_DIR = MODULE_DIR / "examples"
+EXAMPLES_DIR = MODULE_DIR / 'examples'
 
 
 @pytest.mark.parametrize(
-    "idx_and_options",
+    'idx_and_options',
     enumerate(
         [
             [],
-            ["-c"],
-            ["-d"],
-            ["-z"],
-            ["-d", "-z"],
-            ["-B", "7"],  # Odd number of bulk calls
-            ["-P", "TEMPFILE"],
+            ['-c'],
+            ['-d'],
+            ['-z'],
+            ['-d', '-z'],
+            ['-B', '7'],  # Odd number of bulk calls
+            ['-P', 'TEMPFILE'],
         ]
     ),
 )
@@ -33,7 +34,7 @@ def test_example_objectstore(temp_dir, idx_and_options):
 
     tempfile_idx = None
     try:
-        tempfile_idx = options.index("TEMPFILE")
+        tempfile_idx = options.index('TEMPFILE')
         context = tempfile.NamedTemporaryFile()
     except ValueError:
         # no need to create a tempfile
@@ -42,32 +43,32 @@ def test_example_objectstore(temp_dir, idx_and_options):
     with context as tmpfile:
         if tempfile_idx is not None:
             options[tempfile_idx] = tmpfile.name
-        script = EXAMPLES_DIR / "example_objectstore.py"
+        script = EXAMPLES_DIR / 'example_objectstore.py'
         output = subprocess.check_output(
-            [sys.executable, script, "-p", str(temp_dir / str(idx))] + options
+            [sys.executable, script, '-p', str(temp_dir / str(idx))] + options
         )
-        assert output != ""
+        assert output != ''
 
 
 @pytest.mark.parametrize(
-    "idx_and_options",
+    'idx_and_options',
     enumerate(
         [
             [],
-            ["-c"],
-            ["-m"],
-            ["-z"],
-            ["-z", "-m"],
-            ["-l"],
-            ["-m", "-l"],
+            ['-c'],
+            ['-m'],
+            ['-z'],
+            ['-z', '-m'],
+            ['-l'],
+            ['-m', '-l'],
         ]
     ),
 )
 def test_example_profile_zeros(temp_dir, idx_and_options):
     """Test the example/profiling script 'profile_zeros'."""
     idx, options = idx_and_options
-    script = EXAMPLES_DIR / "profile_zeros.py"
+    script = EXAMPLES_DIR / 'profile_zeros.py'
     output = subprocess.check_output(
-        [sys.executable, str(script), "-p", str(temp_dir / str(idx))] + options
+        [sys.executable, str(script), '-p', str(temp_dir / str(idx))] + options
     )
-    assert output != ""
+    assert output != ''

--- a/tests/test_optional.py
+++ b/tests/test_optional.py
@@ -1,5 +1,6 @@
 """Additional optional tests to check additional functionality, such as
 if the library works also with other external optional modules."""
+
 from pathlib import Path
 
 import numpy as np
@@ -7,25 +8,25 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "do_pack,compress", [[False, False], [True, False], [True, True]]
+    'do_pack,compress', [[False, False], [True, False], [True, True]]
 )
-@pytest.mark.parametrize("hdf5_compression", [None, "gzip"])
+@pytest.mark.parametrize('hdf5_compression', [None, 'gzip'])
 def test_hdf5(temp_container, temp_dir, hdf5_compression, do_pack, compress):
     """Write and read a h5py file.
 
     This test is relevnt because when reading a HDF5 file, the library uses whence=1 or 2,
     we thus want to check that this works correctly also when using various versions of
     the disk-objectstore."""
-    h5py = pytest.importorskip("h5py")
+    h5py = pytest.importorskip('h5py')
 
     ref = np.random.rand(100, 100)
 
     # Create an h5 file
-    filepath = Path(temp_dir) / "array.h5"
-    with h5py.File(filepath, "w") as h5obj:
-        h5obj.create_dataset("array", data=ref, compression=hdf5_compression)
+    filepath = Path(temp_dir) / 'array.h5'
+    with h5py.File(filepath, 'w') as h5obj:
+        h5obj.create_dataset('array', data=ref, compression=hdf5_compression)
 
-    with open(filepath, "rb") as fhandle:
+    with open(filepath, 'rb') as fhandle:
         hashkey = temp_container.add_streamed_object(fhandle)
 
     if do_pack:
@@ -34,9 +35,9 @@ def test_hdf5(temp_container, temp_dir, hdf5_compression, do_pack, compress):
 
     # Read from the file
     with temp_container.get_object_stream(hashkey) as stream:
-        with h5py.File(stream, "r") as h5obj:
+        with h5py.File(stream, 'r') as h5obj:
             # Read the data back, the [:] is needed to return
             # the numpy array (in memory)
-            data = h5obj["array"][:]
+            data = h5obj['array'][:]
 
     assert np.allclose(data, ref)

--- a/tests/test_optional.py
+++ b/tests/test_optional.py
@@ -7,9 +7,7 @@ import numpy as np
 import pytest
 
 
-@pytest.mark.parametrize(
-    'do_pack,compress', [[False, False], [True, False], [True, True]]
-)
+@pytest.mark.parametrize('do_pack,compress', [[False, False], [True, False], [True, True]])
 @pytest.mark.parametrize('hdf5_compression', [None, 'gzip'])
 def test_hdf5(temp_container, temp_dir, hdf5_compression, do_pack, compress):
     """Write and read a h5py file.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 """Test of the utils wrappers."""
+
 # pylint: disable=too-many-lines,protected-access
 import functools
 import hashlib
@@ -16,22 +17,20 @@ from disk_objectstore import utils
 # I need these definitions later for the mocked function
 os._actual_replace_function = os.replace  # pylint: disable=protected-access
 os._actual_rename_function = os.rename  # pylint: disable=protected-access
-utils._actual_compute_hash_for_file = (
-    utils._compute_hash_for_file
-)  # pylint: disable=protected-access
+utils._actual_compute_hash_for_file = utils._compute_hash_for_file  # pylint: disable=protected-access
 
 # This is used by the mockreplace function to store files that are
 # reopened as locked, to be closed before the test finishes
 LOCKED_FILES_FD = []
 
 # NOTE: test_compressers must be adapted by hand when adding new algorithms
-COMPRESSION_ALGORITHMS_TO_TEST = ["zlib+1", "zlib+9"]
+COMPRESSION_ALGORITHMS_TO_TEST = ['zlib+1', 'zlib+9']
 
 
 def test_lazy_opener_read():
     """Test the LazyOpener."""
-    content = b"sfdssdfd 34fwfd"
-    with tempfile.NamedTemporaryFile(mode="bw", delete=False) as fhandle:
+    content = b'sfdssdfd 34fwfd'
+    with tempfile.NamedTemporaryFile(mode='bw', delete=False) as fhandle:
         fhandle.write(content)
 
     try:
@@ -40,14 +39,14 @@ def test_lazy_opener_read():
         lazy = utils.LazyOpener(Path(fhandle.name))
 
         assert lazy.path == Path(fhandle.name)
-        assert lazy.mode == "rb"
+        assert lazy.mode == 'rb'
         with pytest.raises(ValueError):
             # This is not open yet
             lazy.tell()
 
         assert (
             len(current_process.open_files()) == start_open_files
-        ), "The LazyOpener is not lazy, but axtually opened the file instead!"
+        ), 'The LazyOpener is not lazy, but axtually opened the file instead!'
         with lazy as fhandle:
             # Shoul be opened at position zero at the beginnign
             assert lazy.tell() == 0
@@ -57,12 +56,12 @@ def test_lazy_opener_read():
 
             assert (
                 len(current_process.open_files()) == start_open_files + 1
-            ), "The count of open files is wrong!"
-            assert read_content == content, "Unexpected content read from file"
+            ), 'The count of open files is wrong!'
+            assert read_content == content, 'Unexpected content read from file'
 
         assert (
             len(current_process.open_files()) == start_open_files
-        ), "The LazyOpener did not close the file on exit!"
+        ), 'The LazyOpener did not close the file on exit!'
 
         with pytest.raises(ValueError):
             # Should raise again after closing
@@ -73,8 +72,8 @@ def test_lazy_opener_read():
 
 def test_lazy_opener_not_twice():
     """Test that the LazyOpener cannot be opened twice."""
-    content = b"sfdfsdj2322d"
-    with tempfile.NamedTemporaryFile(mode="bw", delete=False) as fhandle:
+    content = b'sfdfsdj2322d'
+    with tempfile.NamedTemporaryFile(mode='bw', delete=False) as fhandle:
         fhandle.write(content)
 
     try:
@@ -86,7 +85,7 @@ def test_lazy_opener_not_twice():
             with pytest.raises(IOError) as excinfo:
                 with lazy:
                     pass
-            assert "already open" in str(excinfo.value)
+            assert 'already open' in str(excinfo.value)
             # The exception should not have corrupted the first stream
             assert fhandle.read() == content
     finally:
@@ -95,21 +94,21 @@ def test_lazy_opener_not_twice():
 
 def test_nullcontext():
     """Test the nullcontext."""
-    result = "something"
+    result = 'something'
     with utils.nullcontext(enter_result=result) as manager:
         assert manager == result
 
 
-@pytest.mark.parametrize("loose_prefix_len", [0, 2, 3])
+@pytest.mark.parametrize('loose_prefix_len', [0, 2, 3])
 def test_object_writer(temp_dir, loose_prefix_len):
     """Test the ObjectWriter, directly writing objects (loose, via a sandbox)."""
-    sandbox_folder = temp_dir / "sandbox"
-    loose_folder = temp_dir / "loose"
-    duplicates_folder = temp_dir / "duplicates"
+    sandbox_folder = temp_dir / 'sandbox'
+    loose_folder = temp_dir / 'loose'
+    duplicates_folder = temp_dir / 'duplicates'
 
-    hash_type = "sha256"
-    expected_hash = "9975d00a6e715d830aeaa035347b3e601a0c0bb457a7f87816300e7c01c0c39b"
-    content = b"some-content-to-hash"
+    hash_type = 'sha256'
+    expected_hash = '9975d00a6e715d830aeaa035347b3e601a0c0bb457a7f87816300e7c01c0c39b'
+    content = b'some-content-to-hash'
 
     # Create the two folders, make sure they
     # are empty
@@ -159,15 +158,15 @@ def test_object_writer(temp_dir, loose_prefix_len):
         )
     else:
         loose_filename = loose_folder / obj_hashkey
-    with open(loose_filename, "rb") as fhandle:
+    with open(loose_filename, 'rb') as fhandle:
         assert fhandle.read() == content
 
 
 def test_object_writer_duplicates_function(temp_dir):  # pylint: disable=invalid-name
     """Test that the _store_duplicate_copy function works."""
-    sandbox_folder = temp_dir / "sandbox"
-    loose_folder = temp_dir / "loose"
-    duplicates_folder = temp_dir / "duplicates"
+    sandbox_folder = temp_dir / 'sandbox'
+    loose_folder = temp_dir / 'loose'
+    duplicates_folder = temp_dir / 'duplicates'
     os.mkdir(sandbox_folder)
     os.mkdir(loose_folder)
     os.mkdir(duplicates_folder)
@@ -175,8 +174,8 @@ def test_object_writer_duplicates_function(temp_dir):  # pylint: disable=invalid
     # The duplicates folder should be empty at the beginning
     assert not os.listdir(duplicates_folder)
 
-    content = b"24tq34waSDV"
-    hash_type = "sha256"
+    content = b'24tq34waSDV'
+    hash_type = 'sha256'
 
     object_writer = utils.ObjectWriter(
         sandbox_folder=sandbox_folder,
@@ -186,8 +185,8 @@ def test_object_writer_duplicates_function(temp_dir):  # pylint: disable=invalid
         hash_type=hash_type,
     )
 
-    temp_path = sandbox_folder / "tmp-file-name"
-    with open(temp_path, "wb") as fhandle:
+    temp_path = sandbox_folder / 'tmp-file-name'
+    with open(temp_path, 'wb') as fhandle:
         fhandle.write(content)
     hashkey = getattr(hashlib, hash_type)(content).hexdigest()
 
@@ -198,30 +197,30 @@ def test_object_writer_duplicates_function(temp_dir):  # pylint: disable=invalid
     duplicates_files = os.listdir(duplicates_folder)
     assert (
         len(duplicates_files) == 1
-    ), f"There is more than one file in the duplicates! {duplicates_files}"
+    ), f'There is more than one file in the duplicates! {duplicates_files}'
     duplicates_file = duplicates_files[0]
     # The duplicate should start with the hashkey followed by a dot
-    assert duplicates_file.startswith(f"{hashkey}.")
+    assert duplicates_file.startswith(f'{hashkey}.')
 
 
 def test_object_writer_with_exc(temp_dir):
     """Test that the ObjectWriter does not write anything if there is an exception."""
-    sandbox_folder = temp_dir / "sandbox"
-    loose_folder = temp_dir / "loose"
-    duplicates_folder = temp_dir / "duplicates"
+    sandbox_folder = temp_dir / 'sandbox'
+    loose_folder = temp_dir / 'loose'
+    duplicates_folder = temp_dir / 'duplicates'
     loose_prefix_len = 2
     os.mkdir(sandbox_folder)
     os.mkdir(loose_folder)
     os.mkdir(duplicates_folder)
 
-    content = b"523453dfvsd"
+    content = b'523453dfvsd'
 
     object_writer = utils.ObjectWriter(
         sandbox_folder=sandbox_folder,
         loose_folder=loose_folder,
         loose_prefix_len=loose_prefix_len,
         duplicates_folder=duplicates_folder,
-        hash_type="sha256",
+        hash_type='sha256',
     )
 
     assert not os.listdir(sandbox_folder)
@@ -236,8 +235,8 @@ def test_object_writer_with_exc(temp_dir):
             assert len(os.listdir(sandbox_folder)) == 1
             assert not os.listdir(loose_folder)
 
-            raise ValueError("My Error")
-    assert str(excinfo.value) == "My Error"
+            raise ValueError('My Error')
+    assert str(excinfo.value) == 'My Error'
 
     # Since the exception was raised, both
     # the sandbox folder and the loose folder should
@@ -248,22 +247,22 @@ def test_object_writer_with_exc(temp_dir):
 
 def test_object_writer_manual_close(temp_dir):
     """Test that the ObjectWriter does not allow manually closing the stream."""
-    sandbox_folder = temp_dir / "sandbox"
-    loose_folder = temp_dir / "loose"
-    duplicates_folder = temp_dir / "duplicates"
+    sandbox_folder = temp_dir / 'sandbox'
+    loose_folder = temp_dir / 'loose'
+    duplicates_folder = temp_dir / 'duplicates'
     loose_prefix_len = 2
     os.mkdir(sandbox_folder)
     os.mkdir(loose_folder)
     os.mkdir(duplicates_folder)
 
-    content = b"523453dfvsd"
+    content = b'523453dfvsd'
 
     object_writer = utils.ObjectWriter(
         sandbox_folder=sandbox_folder,
         loose_folder=loose_folder,
         loose_prefix_len=loose_prefix_len,
         duplicates_folder=duplicates_folder,
-        hash_type="sha256",
+        hash_type='sha256',
     )
 
     assert not os.listdir(sandbox_folder)
@@ -279,7 +278,7 @@ def test_object_writer_manual_close(temp_dir):
             assert not os.listdir(loose_folder)
             fhandle.close()
 
-    assert "You cannot close" in str(excinfo.value)
+    assert 'You cannot close' in str(excinfo.value)
 
     # Since the exception was raised, both
     # the sandbox folder and the loose folder should
@@ -290,22 +289,22 @@ def test_object_writer_manual_close(temp_dir):
 
 def test_object_writer_not_twice(temp_dir):
     """Test that the ObjectWriter cannot be opened twice."""
-    sandbox_folder = temp_dir / "sandbox"
-    loose_folder = temp_dir / "loose"
-    duplicates_folder = temp_dir / "duplicates"
+    sandbox_folder = temp_dir / 'sandbox'
+    loose_folder = temp_dir / 'loose'
+    duplicates_folder = temp_dir / 'duplicates'
     loose_prefix_len = 2
     os.mkdir(sandbox_folder)
     os.mkdir(loose_folder)
     os.mkdir(duplicates_folder)
 
-    content = b"523453dfvsd"
+    content = b'523453dfvsd'
 
     object_writer = utils.ObjectWriter(
         sandbox_folder=sandbox_folder,
         loose_folder=loose_folder,
         loose_prefix_len=loose_prefix_len,
         duplicates_folder=duplicates_folder,
-        hash_type="sha256",
+        hash_type='sha256',
     )
 
     # The first open should go through
@@ -316,7 +315,7 @@ def test_object_writer_not_twice(temp_dir):
         with pytest.raises(IOError) as excinfo:
             with object_writer:
                 pass
-        assert "already opened" in str(excinfo.value)
+        assert 'already opened' in str(excinfo.value)
         # The exception should not have corrupted the first stream. I write again something
         fhandle.write(content)
 
@@ -324,7 +323,7 @@ def test_object_writer_not_twice(temp_dir):
     loose_filename = (
         loose_folder / obj_hashkey[:loose_prefix_len] / obj_hashkey[loose_prefix_len:]
     )
-    with open(loose_filename, "rb") as fhandle:
+    with open(loose_filename, 'rb') as fhandle:
         # I have written the content twice
         assert fhandle.read() == content + content
 
@@ -332,34 +331,34 @@ def test_object_writer_not_twice(temp_dir):
         # Should not allow to reuse the same object_writer after storing
         with object_writer:
             pass
-    assert "already tried to store" in str(excinfo.value)
+    assert 'already tried to store' in str(excinfo.value)
 
 
-@pytest.mark.skipif(os.name != "nt", reason="This test only makes sense on Windows")
-@pytest.mark.parametrize("trust_existing", [True, False])
+@pytest.mark.skipif(os.name != 'nt', reason='This test only makes sense on Windows')
+@pytest.mark.parametrize('trust_existing', [True, False])
 def test_object_writer_existing_locked(  # pylint: disable=invalid-name
     temp_dir, trust_existing, lock_file_on_windows
 ):
     """If I am adding a new loose object, and it exists already, and it's locked, I cannot check its content.
 
     Therefore, I should be creating a copy, unless I am trusting existing files."""
-    sandbox_folder = temp_dir / "sandbox"
-    loose_folder = temp_dir / "loose"
-    duplicates_folder = temp_dir / "duplicates"
+    sandbox_folder = temp_dir / 'sandbox'
+    loose_folder = temp_dir / 'loose'
+    duplicates_folder = temp_dir / 'duplicates'
     loose_prefix_len = 2
-    hash_type = "sha256"
+    hash_type = 'sha256'
     os.mkdir(sandbox_folder)
     os.mkdir(loose_folder)
     os.mkdir(duplicates_folder)
 
-    content = b"523453dfvsd"
+    content = b'523453dfvsd'
     hasher = utils.get_hash_cls(hash_type=hash_type)()
     hasher.update(content)
     hashkey = hasher.hexdigest()
 
     loose_file = loose_folder / hashkey[:loose_prefix_len] / hashkey[loose_prefix_len:]
     os.mkdir(loose_file.parent)
-    with open(loose_file, "wb") as fhandle:
+    with open(loose_file, 'wb') as fhandle:
         fhandle.write(content)
 
     # Check the starting condition
@@ -393,8 +392,8 @@ def test_object_writer_existing_locked(  # pylint: disable=invalid-name
         duplicates_files = os.listdir(duplicates_folder)
         assert len(duplicates_files) == 1
         duplicates_file = duplicates_files[0]
-        assert duplicates_file.startswith(f"{hashkey}.")
-        with open(duplicates_folder / duplicates_file, "rb") as fhandle:
+        assert duplicates_file.startswith(f'{hashkey}.')
+        with open(duplicates_folder / duplicates_file, 'rb') as fhandle:
             # Check that the duplicate has the right content
             assert fhandle.read() == content
 
@@ -405,10 +404,10 @@ def test_object_writer_existing_locked(  # pylint: disable=invalid-name
     assert len(os.listdir(loose_file.parent)) == 1
 
 
-@pytest.mark.skipif(os.name != "nt", reason="This test only makes sense on Windows")
-@pytest.mark.parametrize("lock_new_file", [True, False])
-@pytest.mark.parametrize("reappears_corrupted", [True, False])
-@pytest.mark.parametrize("trust_existing", [True, False])
+@pytest.mark.skipif(os.name != 'nt', reason='This test only makes sense on Windows')
+@pytest.mark.parametrize('lock_new_file', [True, False])
+@pytest.mark.parametrize('reappears_corrupted', [True, False])
+@pytest.mark.parametrize('trust_existing', [True, False])
 def test_object_writer_appears_concurrently(  # pylint: disable=invalid-name,too-many-arguments),too-many-locals
     temp_dir,
     trust_existing,
@@ -426,21 +425,21 @@ def test_object_writer_appears_concurrently(  # pylint: disable=invalid-name,too
         NOTE: This can only be done on Windows.
     """
     # Needed by the mocked function, but we need as well here to close the files before the test ends
-    sandbox_folder = temp_dir / "sandbox"
-    loose_folder = temp_dir / "loose"
-    duplicates_folder = temp_dir / "duplicates"
+    sandbox_folder = temp_dir / 'sandbox'
+    loose_folder = temp_dir / 'loose'
+    duplicates_folder = temp_dir / 'duplicates'
     loose_prefix_len = 2
-    hash_type = "sha256"
+    hash_type = 'sha256'
     os.mkdir(sandbox_folder)
     os.mkdir(loose_folder)
     os.mkdir(duplicates_folder)
 
-    content = b"523453dfvsd"
+    content = b'523453dfvsd'
     hasher = utils.get_hash_cls(hash_type=hash_type)()
     hasher.update(content)
     hashkey = hasher.hexdigest()
 
-    corrupted_content = b"SOME_CORRUPTED_CONTENT"
+    corrupted_content = b'SOME_CORRUPTED_CONTENT'
 
     loose_file = loose_folder / hashkey[:loose_prefix_len] / hashkey[loose_prefix_len:]
     # Just prepare the parent folder, but don't put any file
@@ -470,7 +469,7 @@ def test_object_writer_appears_concurrently(  # pylint: disable=invalid-name,too
         if Path(dest).resolve() == Path(mocked_dest).resolve():
             # Write a file just before calling the rename function, in this case
             # The folder should have been already created
-            with open(dest, "wb") as fhandle:
+            with open(dest, 'wb') as fhandle:
                 fhandle.write(new_bytes_content)
 
             if lock_new_file:
@@ -485,7 +484,7 @@ def test_object_writer_appears_concurrently(  # pylint: disable=invalid-name,too
     new_bytes_content = corrupted_content if reappears_corrupted else content
     monkeypatch.setattr(
         os,
-        "rename",
+        'rename',
         functools.partial(
             mockrename,
             mocked_dest=loose_file,
@@ -521,19 +520,19 @@ def test_object_writer_appears_concurrently(  # pylint: disable=invalid-name,too
         duplicates_files = os.listdir(duplicates_folder)
         assert len(duplicates_files) == 1
         duplicates_file = duplicates_files[0]
-        assert duplicates_file.startswith(f"{hashkey}.")
-        with open(duplicates_folder / duplicates_file, "rb") as fhandle:
+        assert duplicates_file.startswith(f'{hashkey}.')
+        with open(duplicates_folder / duplicates_file, 'rb') as fhandle:
             # Check that the duplicate has the right content
             assert fhandle.read() == content
 
     # Let's check the content of the file - this should never have changed from what we wrote at the beginning
-    with open(loose_file, "rb") as fhandle:
+    with open(loose_file, 'rb') as fhandle:
         assert fhandle.read() == new_bytes_content
 
 
-@pytest.mark.parametrize("dest_is_open", [True, False])
-@pytest.mark.parametrize("reappears_corrupted", [True, False])
-@pytest.mark.parametrize("trust_existing", [True, False])
+@pytest.mark.parametrize('dest_is_open', [True, False])
+@pytest.mark.parametrize('reappears_corrupted', [True, False])
+@pytest.mark.parametrize('trust_existing', [True, False])
 def test_object_writer_existing_corrupted_reappears(  # pylint: disable=invalid-name, too-many-locals, too-many-statements
     temp_dir, trust_existing, reappears_corrupted, dest_is_open, monkeypatch
 ):
@@ -547,26 +546,26 @@ def test_object_writer_existing_corrupted_reappears(  # pylint: disable=invalid-
     so I should get a duplicate *ONLY* if I don't trust existing objects AND I rewrite a corrupted file AND the file
     is kept open, so I cannot rewrite it.
     """
-    sandbox_folder = temp_dir / "sandbox"
-    loose_folder = temp_dir / "loose"
-    duplicates_folder = temp_dir / "duplicates"
+    sandbox_folder = temp_dir / 'sandbox'
+    loose_folder = temp_dir / 'loose'
+    duplicates_folder = temp_dir / 'duplicates'
     loose_prefix_len = 2
-    hash_type = "sha256"
+    hash_type = 'sha256'
     os.mkdir(sandbox_folder)
     os.mkdir(loose_folder)
     os.mkdir(duplicates_folder)
 
-    content = b"523453dfvsd"
+    content = b'523453dfvsd'
     hasher = utils.get_hash_cls(hash_type=hash_type)()
     hasher.update(content)
     hashkey = hasher.hexdigest()
 
     # Some content that does not match the hash key
-    corrupted_content = b"CORRUPTED CONTENT"
+    corrupted_content = b'CORRUPTED CONTENT'
 
     loose_file = loose_folder / hashkey[:loose_prefix_len] / hashkey[loose_prefix_len:]
     os.mkdir(loose_file.parent)
-    with open(loose_file, "wb") as fhandle:
+    with open(loose_file, 'wb') as fhandle:
         fhandle.write(corrupted_content)
 
     # Check the starting condition
@@ -592,20 +591,16 @@ def test_object_writer_existing_corrupted_reappears(  # pylint: disable=invalid-
         """
         if Path(dest).resolve() == Path(mocked_dest).resolve():
             # Write back the file, with possibly a different content
-            with open(dest, "wb") as fhandle:
+            with open(dest, 'wb') as fhandle:
                 fhandle.write(new_bytes_content)
 
             # Call the actual replace function, but while the file is open in read mode
             # This will fail on Windows
             if dest_is_open:
-                with open(dest, "rb") as fhandle:
-                    os._actual_replace_function(
-                        src, dest
-                    )  # pylint: disable=protected-access
+                with open(dest, 'rb') as fhandle:
+                    os._actual_replace_function(src, dest)  # pylint: disable=protected-access
             else:
-                os._actual_replace_function(
-                    src, dest
-                )  # pylint: disable=protected-access
+                os._actual_replace_function(src, dest)  # pylint: disable=protected-access
         else:
             # It's a different path: just pipe through
             # I renamed this at module load to avoid infinite recursion, see above
@@ -614,7 +609,7 @@ def test_object_writer_existing_corrupted_reappears(  # pylint: disable=invalid-
     new_bytes_content = corrupted_content if reappears_corrupted else content
     monkeypatch.setattr(
         os,
-        "replace",
+        'replace',
         functools.partial(
             mockreplacefail,
             mocked_dest=loose_file,
@@ -627,14 +622,14 @@ def test_object_writer_existing_corrupted_reappears(  # pylint: disable=invalid-
     with object_writer as fhandle:
         fhandle.write(content)
 
-    if os.name == "nt" and not trust_existing and dest_is_open:
+    if os.name == 'nt' and not trust_existing and dest_is_open:
         # On Windows, if the file reappears, is corrupted, and cannot be replaced (is open),
         # then we store a duplicate copy.
         duplicates_files = os.listdir(duplicates_folder)
         assert len(duplicates_files) == 1
         duplicates_file = duplicates_files[0]
-        assert duplicates_file.startswith(f"{hashkey}.")
-        with open(duplicates_folder / duplicates_file, "rb") as fhandle:
+        assert duplicates_file.startswith(f'{hashkey}.')
+        with open(duplicates_folder / duplicates_file, 'rb') as fhandle:
             # Check that the duplicate has the right content
             assert fhandle.read() == content
     else:
@@ -653,31 +648,27 @@ def test_object_writer_existing_corrupted_reappears(  # pylint: disable=invalid-
     assert len(os.listdir(loose_file.parent)) == 1
 
     # Check now the content
-    with open(loose_file, "rb") as fhandle:
+    with open(loose_file, 'rb') as fhandle:
         object_content = fhandle.read()
 
     if trust_existing:
         # If I trust existing files, the content shouldn't have been touched
         # (and the logic for reappears_corrupted is not really triggered)
         assert object_content == corrupted_content
+    elif (
+        os.name == 'nt' and not trust_existing and reappears_corrupted and dest_is_open
+    ):
+        # Only in this extreme case (don't trust existing, the file reappears, it is
+        # corrupted, and I couldn't overwrite the dest (loose file) because it was open,
+        # then I'm left with the old content)
+        assert object_content == corrupted_content
     else:
-        if (
-            os.name == "nt"
-            and not trust_existing
-            and reappears_corrupted
-            and dest_is_open
-        ):
-            # Only in this extreme case (don't trust existing, the file reappears, it is
-            # corrupted, and I couldn't overwrite the dest (loose file) because it was open,
-            # then I'm left with the old content)
-            assert object_content == corrupted_content
-        else:
-            # In all other cases, if I don't trust existing files, the content should have been replaced,
-            # and and if the DynamicInconsistentContent exception wasn't raised, the content must be correct
-            assert object_content == content
+        # In all other cases, if I don't trust existing files, the content should have been replaced,
+        # and and if the DynamicInconsistentContent exception wasn't raised, the content must be correct
+        assert object_content == content
 
 
-@pytest.mark.parametrize("object_existed", [True, False])
+@pytest.mark.parametrize('object_existed', [True, False])
 def test_object_writer_deleted_while_checking_content(  # pylint: disable=invalid-name
     temp_dir, object_existed, monkeypatch
 ):
@@ -686,17 +677,17 @@ def test_object_writer_deleted_while_checking_content(  # pylint: disable=invali
     I check both the case in which the object existed, and the one in which it didn't (in which case, the
     mocking shouldn't do anything).
     """
-    sandbox_folder = temp_dir / "sandbox"
-    loose_folder = temp_dir / "loose"
-    duplicates_folder = temp_dir / "duplicates"
+    sandbox_folder = temp_dir / 'sandbox'
+    loose_folder = temp_dir / 'loose'
+    duplicates_folder = temp_dir / 'duplicates'
     loose_prefix_len = 2
-    hash_type = "sha256"
+    hash_type = 'sha256'
     trust_existing = False  # This branch is only called in this case
     os.mkdir(sandbox_folder)
     os.mkdir(loose_folder)
     os.mkdir(duplicates_folder)
 
-    content = b"523453dfvsd"
+    content = b'523453dfvsd'
     hasher = utils.get_hash_cls(hash_type=hash_type)()
     hasher.update(content)
     hashkey = hasher.hexdigest()
@@ -707,7 +698,7 @@ def test_object_writer_deleted_while_checking_content(  # pylint: disable=invali
 
     # Create the object, if `object_existed` is True (meaning that it existed before calling the ObjectWriter)
     if object_existed:
-        with open(loose_file, "wb") as fhandle:
+        with open(loose_file, 'wb') as fhandle:
             fhandle.write(content)
 
     # Check the starting condition
@@ -734,7 +725,7 @@ def test_object_writer_deleted_while_checking_content(  # pylint: disable=invali
 
     monkeypatch.setattr(
         utils,
-        "_compute_hash_for_file",
+        '_compute_hash_for_file',
         functools.partial(mock_compute_hash, mocked_filename=loose_file),
     )
 
@@ -762,21 +753,19 @@ def test_object_writer_deleted_while_checking_content(  # pylint: disable=invali
     assert len(os.listdir(loose_file.parent)) == (0 if object_existed else 1)
 
 
-@pytest.mark.parametrize("trust_existing", [True, False])
-def test_object_writer_existing_OK(
-    temp_dir, trust_existing
-):  # pylint: disable=invalid-name
+@pytest.mark.parametrize('trust_existing', [True, False])
+def test_object_writer_existing_OK(temp_dir, trust_existing):  # pylint: disable=invalid-name
     """Test that the ObjectWriter works if the loose object already exists (with the correct content)."""
-    sandbox_folder = temp_dir / "sandbox"
-    loose_folder = temp_dir / "loose"
-    duplicates_folder = temp_dir / "duplicates"
+    sandbox_folder = temp_dir / 'sandbox'
+    loose_folder = temp_dir / 'loose'
+    duplicates_folder = temp_dir / 'duplicates'
     loose_prefix_len = 2
-    hash_type = "sha256"
+    hash_type = 'sha256'
     os.mkdir(sandbox_folder)
     os.mkdir(loose_folder)
     os.mkdir(duplicates_folder)
 
-    content = b"523453dfvsd"
+    content = b'523453dfvsd'
     hasher = utils.get_hash_cls(hash_type=hash_type)()
     hasher.update(content)
     hashkey = hasher.hexdigest()
@@ -784,7 +773,7 @@ def test_object_writer_existing_OK(
     # Write already the content in place
     loose_file = loose_folder / hashkey[:loose_prefix_len] / hashkey[loose_prefix_len:]
     os.mkdir(loose_file.parent)
-    with open(loose_file, "wb") as fhandle:
+    with open(loose_file, 'wb') as fhandle:
         fhandle.write(content)
 
     # Check the starting condition
@@ -812,37 +801,35 @@ def test_object_writer_existing_OK(
     assert len(os.listdir(loose_file.parent)) == 1
 
     # Check now the content
-    with open(loose_file, "rb") as fhandle:
+    with open(loose_file, 'rb') as fhandle:
         object_content = fhandle.read()
 
     assert object_content == content
 
 
-@pytest.mark.parametrize("trust_existing", [True, False])
-def test_object_writer_existing_corrupted(
-    temp_dir, trust_existing
-):  # pylint: disable=invalid-name
+@pytest.mark.parametrize('trust_existing', [True, False])
+def test_object_writer_existing_corrupted(temp_dir, trust_existing):  # pylint: disable=invalid-name
     """Test that the ObjectWriter replaces an existing corrupted (wrong hash) loose object."""
-    sandbox_folder = temp_dir / "sandbox"
-    loose_folder = temp_dir / "loose"
-    duplicates_folder = temp_dir / "duplicates"
+    sandbox_folder = temp_dir / 'sandbox'
+    loose_folder = temp_dir / 'loose'
+    duplicates_folder = temp_dir / 'duplicates'
     loose_prefix_len = 2
-    hash_type = "sha256"
+    hash_type = 'sha256'
     os.mkdir(sandbox_folder)
     os.mkdir(loose_folder)
     os.mkdir(duplicates_folder)
 
-    content = b"523453dfvsd"
+    content = b'523453dfvsd'
     hasher = utils.get_hash_cls(hash_type=hash_type)()
     hasher.update(content)
     hashkey = hasher.hexdigest()
 
     # Some content that does not match the hash key
-    corrupted_content = b"CORRUPTED CONTENT"
+    corrupted_content = b'CORRUPTED CONTENT'
 
     loose_file = loose_folder / hashkey[:loose_prefix_len] / hashkey[loose_prefix_len:]
     os.mkdir(loose_file.parent)
-    with open(loose_file, "wb") as fhandle:
+    with open(loose_file, 'wb') as fhandle:
         fhandle.write(corrupted_content)
 
     # Check the starting condition
@@ -870,7 +857,7 @@ def test_object_writer_existing_corrupted(
     assert len(os.listdir(loose_file.parent)) == 1
 
     # Check now the content
-    with open(loose_file, "rb") as fhandle:
+    with open(loose_file, 'rb') as fhandle:
         object_content = fhandle.read()
 
     if trust_existing:
@@ -883,9 +870,9 @@ def test_object_writer_existing_corrupted(
 
 def test_unknown_hash_type(temp_dir):
     """Test that the ObjectWriter does not write anything if there is an exception."""
-    sandbox_folder = temp_dir / "sandbox"
-    loose_folder = temp_dir / "loose"
-    duplicates_folder = temp_dir / "duplicates"
+    sandbox_folder = temp_dir / 'sandbox'
+    loose_folder = temp_dir / 'loose'
+    duplicates_folder = temp_dir / 'duplicates'
     loose_prefix_len = 2
     os.mkdir(sandbox_folder)
     os.mkdir(loose_folder)
@@ -897,18 +884,18 @@ def test_unknown_hash_type(temp_dir):
             loose_folder=loose_folder,
             loose_prefix_len=loose_prefix_len,
             duplicates_folder=duplicates_folder,
-            hash_type="unknown_hash_string",
+            hash_type='unknown_hash_string',
         )
         # The exception is actually raised here
         with object_writer as fhandle:
             # Write some content first
-            fhandle.write("something")
+            fhandle.write('something')
 
 
 def test_packed_object_reader():
     """Test the functionality of the PackedObjectReader."""
-    bytestream = b"0123456789abcdef"
-    with tempfile.NamedTemporaryFile(mode="wb", delete=False) as tempfhandle:
+    bytestream = b'0123456789abcdef'
+    with tempfile.NamedTemporaryFile(mode='wb', delete=False) as tempfhandle:
         tempfhandle.write(bytestream)
 
     offset = 3
@@ -916,7 +903,7 @@ def test_packed_object_reader():
     expected_bytestream = bytestream[offset : offset + length]
 
     # Read 1 byte at a time
-    with open(tempfhandle.name, "rb") as fhandle:
+    with open(tempfhandle.name, 'rb') as fhandle:
         packed_reader = utils.PackedObjectReader(fhandle, offset=offset, length=length)
 
         data = []
@@ -925,10 +912,10 @@ def test_packed_object_reader():
             if not piece:
                 break
             data.append(piece)
-        assert b"".join(data) == expected_bytestream
+        assert b''.join(data) == expected_bytestream
 
     # Read 2 bytes at a time (note that the length is odd, so it's not a multiple)
-    with open(tempfhandle.name, "rb") as fhandle:
+    with open(tempfhandle.name, 'rb') as fhandle:
         packed_reader = utils.PackedObjectReader(fhandle, offset=offset, length=length)
 
         data = []
@@ -937,32 +924,32 @@ def test_packed_object_reader():
             if not piece:
                 break
             data.append(piece)
-        assert b"".join(data) == expected_bytestream
+        assert b''.join(data) == expected_bytestream
 
     # Offset beyond the file limit
-    with open(tempfhandle.name, "rb") as fhandle:
+    with open(tempfhandle.name, 'rb') as fhandle:
         packed_reader = utils.PackedObjectReader(
             fhandle, offset=len(bytestream) + 10, length=length
         )
-        assert packed_reader.read() == b""
+        assert packed_reader.read() == b''
 
     # Offset before the file limit, but longer length
-    with open(tempfhandle.name, "rb") as fhandle:
+    with open(tempfhandle.name, 'rb') as fhandle:
         packed_reader = utils.PackedObjectReader(fhandle, offset=offset, length=1000000)
         assert packed_reader.read() == bytestream[offset:]
 
 
 def test_packed_object_reader_seek(tmp_path):
     """Test the `PackedObjectReader.seek` method."""
-    bytestream = b"0123456789abcdef"
-    with open(str(tmp_path / "pack"), mode="wb") as handle:
+    bytestream = b'0123456789abcdef'
+    with open(str(tmp_path / 'pack'), mode='wb') as handle:
         handle.write(bytestream)
 
     offset = 3
     length = 5
     expected_bytestream = bytestream[offset : offset + length]
 
-    with open(str(tmp_path / "pack"), "rb") as fhandle:
+    with open(str(tmp_path / 'pack'), 'rb') as fhandle:
         packed_reader = utils.PackedObjectReader(fhandle, offset=offset, length=length)
 
         # Check that it is properly marked as seekable
@@ -1033,7 +1020,7 @@ def test_packed_object_reader_mode():
     with tempfile.TemporaryFile() as handle:
         reader = utils.PackedObjectReader(handle, 0, 0)
 
-        assert hasattr(reader, "mode")
+        assert hasattr(reader, 'mode')
         assert reader.mode == handle.mode
 
 
@@ -1041,22 +1028,22 @@ def test_packed_object_reader_context_man(tmp_path):
     """Test the use the of the PackedObjectReader with a context  manager.
 
     Actually, this does not do much, so I'm just testing that it works."""
-    bytestream = b"0123456789abcdef"
-    with open(str(tmp_path / "pack"), mode="wb") as handle:
+    bytestream = b'0123456789abcdef'
+    with open(str(tmp_path / 'pack'), mode='wb') as handle:
         handle.write(bytestream)
 
-    with open(str(tmp_path / "pack"), "rb") as fhandle:
+    with open(str(tmp_path / 'pack'), 'rb') as fhandle:
         with utils.PackedObjectReader(
             fhandle, offset=0, length=len(bytestream)
         ) as packed_reader:
             assert packed_reader.read() == bytestream
 
 
-@pytest.mark.parametrize("open_streams", [True, False])
+@pytest.mark.parametrize('open_streams', [True, False])
 def test_packed_object_reader_add(temp_container, open_streams):
     """Test using `PackedObjectReader` with add_streamed_object_to_pack."""
-    content = b"content"
-    with tempfile.TemporaryFile(mode="rb+") as fhandle:
+    content = b'content'
+    with tempfile.TemporaryFile(mode='rb+') as fhandle:
         fhandle.write(content)
         fhandle.seek(0)
         wrapped = utils.PackedObjectReader(fhandle, 0, len(content))
@@ -1066,7 +1053,7 @@ def test_packed_object_reader_add(temp_container, open_streams):
     assert temp_container.get_object_content(hashkey) == content
 
 
-@pytest.mark.parametrize("compression_algorithm", COMPRESSION_ALGORITHMS_TO_TEST)
+@pytest.mark.parametrize('compression_algorithm', COMPRESSION_ALGORITHMS_TO_TEST)
 def test_stream_decompresser(compression_algorithm):
     """Test the stream decompresser."""
     StreamDecompresser = utils.get_stream_decompresser(  # pylint: disable=invalid-name
@@ -1074,10 +1061,10 @@ def test_stream_decompresser(compression_algorithm):
     )
 
     # A short binary string (1025 bytes, an odd number to avoid possible alignments with the chunk size)
-    original_data_short = b"0123456789abcdef" * 64 + b"E"
+    original_data_short = b'0123456789abcdef' * 64 + b'E'
     # A longish binary string (2097153 bytes ~ 2MB
     # an odd number to avoid possible alignments with the chunk size), compressible
-    original_data_long = b"0123456789abcdef" * 1024 * 128 + b"E"
+    original_data_long = b'0123456789abcdef' * 1024 * 128 + b'E'
     # A longish binary string (~4MB) with random data
     # so typically uncompressible (compressed size is typically larger)
     original_data_long_random = os.urandom(4000000)
@@ -1092,7 +1079,7 @@ def test_stream_decompresser(compression_algorithm):
         compressed_streams.append(io.BytesIO(compressed))
     for original, compressed_stream in zip(original_data, compressed_streams):
         decompresser = StreamDecompresser(compressed_stream)
-        assert decompresser.mode == "rb"
+        assert decompresser.mode == 'rb'
         # Read in one chunk
         with decompresser as handle:
             chunk = handle.read()
@@ -1113,7 +1100,7 @@ def test_stream_decompresser(compression_algorithm):
         assert not tmp
         assert (
             original == decompresser.read()
-        ), "Uncompressed data is wrong (single read)"
+        ), 'Uncompressed data is wrong (single read)'
 
     compressed_streams = []
     for data in original_data:
@@ -1131,18 +1118,18 @@ def test_stream_decompresser(compression_algorithm):
             data_chunks.append(chunk)
             if not chunk:
                 break
-        data = b"".join(data_chunks)
+        data = b''.join(data_chunks)
 
-        assert original == data, "Uncompressed data is wrong (chunked read)"
+        assert original == data, 'Uncompressed data is wrong (chunked read)'
 
 
-@pytest.mark.parametrize("compression_algorithm", COMPRESSION_ALGORITHMS_TO_TEST)
+@pytest.mark.parametrize('compression_algorithm', COMPRESSION_ALGORITHMS_TO_TEST)
 def test_stream_decompresser_seek(compression_algorithm):
     """Test the seek (and tell) functionality of the StreamDecompresser."""
     StreamDecompresser = utils.get_stream_decompresser(  # pylint: disable=invalid-name
         compression_algorithm
     )
-    original_data = b"0123456789abcdefABCDEF"
+    original_data = b'0123456789abcdefABCDEF'
     length = len(original_data)
 
     compresser = utils.get_compressobj_instance(compression_algorithm)
@@ -1208,7 +1195,7 @@ def test_stream_decompresser_seek(compression_algorithm):
         assert decompresser.tell() == length
 
 
-@pytest.mark.parametrize("compression_algorithm", COMPRESSION_ALGORITHMS_TO_TEST)
+@pytest.mark.parametrize('compression_algorithm', COMPRESSION_ALGORITHMS_TO_TEST)
 def test_decompresser_corrupt(compression_algorithm):
     """Test that the stream decompresser raises on a corrupt input."""
     StreamDecompresser = utils.get_stream_decompresser(  # pylint: disable=invalid-name
@@ -1216,13 +1203,13 @@ def test_decompresser_corrupt(compression_algorithm):
     )
 
     # Check that we get an error for an invalid stream of bytes
-    decompresser = StreamDecompresser(io.BytesIO(b"1234543"))
+    decompresser = StreamDecompresser(io.BytesIO(b'1234543'))
     with pytest.raises(ValueError) as excinfo:
         print(decompresser.read())
-    assert "Error while uncompressing data" in str(excinfo.value)
+    assert 'Error while uncompressing data' in str(excinfo.value)
 
     # Check that we get an error for a truncated stream of bytes
-    original_data = b"someDATAotherTHINGS"
+    original_data = b'someDATAotherTHINGS'
     compresser = utils.get_compressobj_instance(compression_algorithm)
     compressed_data = compresser.compress(original_data)
     compressed_data += compresser.flush()
@@ -1232,7 +1219,7 @@ def test_decompresser_corrupt(compression_algorithm):
     decompresser = StreamDecompresser(corrupted_stream)
     with pytest.raises(ValueError) as excinfo:
         print(decompresser.read())
-    assert "problem in the incoming buffer" in str(excinfo.value)
+    assert 'problem in the incoming buffer' in str(excinfo.value)
 
 
 def test_zero_stream_mode():
@@ -1240,7 +1227,7 @@ def test_zero_stream_mode():
     length = 23523
     zero_stream = utils.ZeroStream(length=length)
 
-    assert zero_stream.mode == "rb"
+    assert zero_stream.mode == 'rb'
 
 
 def test_zero_stream_single_read():
@@ -1248,8 +1235,8 @@ def test_zero_stream_single_read():
     length = 23523
     zero_stream = utils.ZeroStream(length=length)
     data = zero_stream.read()
-    assert len(data) == length, "The zero stream produced data of the wrong length"
-    assert data == b"\x00" * length, "The zero stream produced non-zero data"
+    assert len(data) == length, 'The zero stream produced data of the wrong length'
+    assert data == b'\x00' * length, 'The zero stream produced non-zero data'
 
 
 def test_zero_stream_multi_read():
@@ -1264,26 +1251,26 @@ def test_zero_stream_multi_read():
         data_chunks.append(chunk)
         if not chunk:
             break
-    data = b"".join(data_chunks)
-    assert len(data) == length, "The zero stream produced data of the wrong length"
-    assert data == b"\x00" * length, "The zero stream produced non-zero data"
+    data = b''.join(data_chunks)
+    assert len(data) == length, 'The zero stream produced data of the wrong length'
+    assert data == b'\x00' * length, 'The zero stream produced non-zero data'
 
 
 # Set as the second parameter the hash of the 'content' string written below
 # inside the test function
 @pytest.mark.parametrize(
-    "hash_type,expected_hash",
+    'hash_type,expected_hash',
     [
-        ["sha256", "9975d00a6e715d830aeaa035347b3e601a0c0bb457a7f87816300e7c01c0c39b"],
-        ["sha1", "2a0439b5b34b74808b6cc7a2bf04dd02604c20b0"],
+        ['sha256', '9975d00a6e715d830aeaa035347b3e601a0c0bb457a7f87816300e7c01c0c39b'],
+        ['sha1', '2a0439b5b34b74808b6cc7a2bf04dd02604c20b0'],
     ],
 )
 def test_hash_writer_wrapper(temp_dir, hash_type, expected_hash):
     """Test some functionality of the HashWriterWrapper class."""
-    content = b"some-content-to-hash"
-    filename = "test_file"
+    content = b'some-content-to-hash'
+    filename = 'test_file'
 
-    with open(temp_dir / filename, "wb") as fhandle:
+    with open(temp_dir / filename, 'wb') as fhandle:
         wrapped = utils.HashWriterWrapper(fhandle, hash_type=hash_type)
         wrapped.write(content)
         # Check that the flush command does not raise
@@ -1291,9 +1278,9 @@ def test_hash_writer_wrapper(temp_dir, hash_type, expected_hash):
         assert wrapped.hexdigest() == expected_hash
         assert wrapped.hash_type == hash_type
         # Check the mode
-        assert wrapped.mode == "wb"
+        assert wrapped.mode == 'wb'
 
-    with open(temp_dir / filename, "rb") as fhandle:
+    with open(temp_dir / filename, 'rb') as fhandle:
         assert fhandle.read() == content
 
 
@@ -1321,23 +1308,23 @@ def test_chunk_iterator():
 
 def test_compute_hash_from_filename(temp_dir):
     """Check the functionality of the _compute_hash_from_filename function."""
-    content = b"2345j43"
+    content = b'2345j43'
     expected_hash = hashlib.sha256(content).hexdigest()
 
-    fpath = temp_dir / "testfile"
+    fpath = temp_dir / 'testfile'
 
-    with open(fpath, "wb") as fhandle:
+    with open(fpath, 'wb') as fhandle:
         fhandle.write(content)
 
     assert (
         utils._compute_hash_for_file(  # pylint: disable=protected-access
-            fpath, "sha256"
+            fpath, 'sha256'
         )
         == expected_hash
     )
     assert (
         utils._compute_hash_for_file(  # pylint: disable=protected-access
-            temp_dir / "NOT_EXISTENT_FILE", "sha256"
+            temp_dir / 'NOT_EXISTENT_FILE', 'sha256'
         )
         is None
     )
@@ -1346,19 +1333,19 @@ def test_compute_hash_from_filename(temp_dir):
 def test_is_known_hash():
     """Check the functionality of the is_known_hash function."""
     # At least sha256 should be supported
-    assert utils.is_known_hash("sha256")
+    assert utils.is_known_hash('sha256')
     # sha1 should also be supported
-    assert utils.is_known_hash("sha1")
+    assert utils.is_known_hash('sha1')
     # A weird string should not be a valid known hash
-    assert not utils.is_known_hash("SOME_UNKNOWN_HASH_TYPE")
+    assert not utils.is_known_hash('SOME_UNKNOWN_HASH_TYPE')
 
 
-@pytest.mark.parametrize("hash_type", ["sha256", "sha1"])
+@pytest.mark.parametrize('hash_type', ['sha256', 'sha1'])
 def test_compute_hash_and_size(hash_type):
     """Check the funtion to compute the hash and size."""
 
     # Try both a small object, and something larger than the chunk size to have full coverage
-    for content in [b"wgarwfsfsdf", b"3gvn3rnv3o" * 100000]:
+    for content in [b'wgarwfsfsdf', b'3gvn3rnv3o' * 100000]:
         stream = io.BytesIO(content)
 
         expected_hash = getattr(hashlib, hash_type)(content).hexdigest()
@@ -1415,7 +1402,7 @@ LEFT_RIGHT_PAIRS = [
 ]
 
 
-@pytest.mark.parametrize("left,right", LEFT_RIGHT_PAIRS)
+@pytest.mark.parametrize('left,right', LEFT_RIGHT_PAIRS)
 def test_detect_where(left, right):
     """Test the detect_where_sorted function."""
     # Compute the expected result
@@ -1478,7 +1465,7 @@ LEFT_RIGHT_PAIRS_UNSORTED = [
 ]
 
 
-@pytest.mark.parametrize("left,right", LEFT_RIGHT_PAIRS_UNSORTED)
+@pytest.mark.parametrize('left,right', LEFT_RIGHT_PAIRS_UNSORTED)
 def test_detect_where_unsorted(left, right):
     """Test the detect_where_sorted function when the lists are not sorted."""
     with pytest.raises(ValueError):
@@ -1514,34 +1501,34 @@ def test_merge_sorted():
 
 def test_callback_stream_wrapper_none():  # pylint: disable=invalid-name
     """Test the callback stream wrapper with no actual callback."""
-    with tempfile.TemporaryFile(mode="rb+") as fhandle:
-        fhandle.write(b"abc")
+    with tempfile.TemporaryFile(mode='rb+') as fhandle:
+        fhandle.write(b'abc')
         fhandle.seek(0)
 
         wrapped = utils.CallbackStreamWrapper(fhandle, callback=None)
 
-        assert wrapped.mode == "rb+"
+        assert wrapped.mode == 'rb+'
         assert wrapped.seekable()
         # Seek forward; read from byte 1
         wrapped.seek(1)
         assert wrapped.tell() == 1
-        assert wrapped.read() == b"bc"
+        assert wrapped.read() == b'bc'
         assert wrapped.tell() == 3
         # Seek backwards; read from byte 0
         wrapped.seek(0)
-        assert wrapped.read() == b"abc"
+        assert wrapped.read() == b'abc'
 
         wrapped.close_callback()
 
 
-@pytest.mark.parametrize("with_total_length", [True, False])
+@pytest.mark.parametrize('with_total_length', [True, False])
 def test_callback_stream_wrapper(callback_instance, with_total_length):
     """Test the callback stream wrapper."""
-    description = "SOME CALLBACK DESCRIPTION"
+    description = 'SOME CALLBACK DESCRIPTION'
     # Long string so we trigger the update_every logic
-    content = b"abc" * 4000
+    content = b'abc' * 4000
 
-    with tempfile.TemporaryFile(mode="rb+") as fhandle:
+    with tempfile.TemporaryFile(mode='rb+') as fhandle:
         fhandle.write(content)
         fhandle.seek(0)
 
@@ -1557,7 +1544,7 @@ def test_callback_stream_wrapper(callback_instance, with_total_length):
                 fhandle, callback=callback_instance.callback, description=description
             )
 
-        assert wrapped.mode == "rb+"
+        assert wrapped.mode == 'rb+'
         assert wrapped.seekable()
         # Seek forward; read from byte 10
         wrapped.seek(10)
@@ -1578,34 +1565,34 @@ def test_callback_stream_wrapper(callback_instance, with_total_length):
 
     assert callback_instance.performed_actions == [
         {
-            "start_value": {
-                "total": len(content) if with_total_length else 0,
-                "description": description,
+            'start_value': {
+                'total': len(content) if with_total_length else 0,
+                'description': description,
             },
-            "value": len(content),
+            'value': len(content),
         },
         {
-            "start_value": {
-                "total": len(content) if with_total_length else 0,
-                "description": f"{description} [rewind]",
+            'start_value': {
+                'total': len(content) if with_total_length else 0,
+                'description': f'{description} [rewind]',
             },
-            "value": len(content),
+            'value': len(content),
         },
         {
-            "start_value": {
-                "total": len(content) if with_total_length else 0,
-                "description": f"{description} [rewind]",
+            'start_value': {
+                'total': len(content) if with_total_length else 0,
+                'description': f'{description} [rewind]',
             },
-            "value": 2,
+            'value': 2,
         },
     ]
 
 
-@pytest.mark.parametrize("open_streams", [True, False])
+@pytest.mark.parametrize('open_streams', [True, False])
 def test_callback_stream_wrapper_add(temp_container, open_streams):
     """Test using callback stream wrapper with add_streamed_object_to_pack."""
-    content = b"content"
-    with tempfile.TemporaryFile(mode="rb+") as fhandle:
+    content = b'content'
+    with tempfile.TemporaryFile(mode='rb+') as fhandle:
         fhandle.write(content)
         fhandle.seek(0)
         wrapped = utils.CallbackStreamWrapper(fhandle, None)
@@ -1617,9 +1604,9 @@ def test_callback_stream_wrapper_add(temp_container, open_streams):
 
 def test_rename_callback(callback_instance):
     """Check the rename_callback function."""
-    old_description = "original description"
-    new_description = "SOME NEW DESC"
-    content = b"some content"
+    old_description = 'original description'
+    new_description = 'SOME NEW DESC'
+    content = b'some content'
 
     assert utils.rename_callback(None, new_description=new_description) is None
 
@@ -1651,30 +1638,30 @@ def test_rename_callback(callback_instance):
 
     assert callback_instance.performed_actions == [
         {
-            "start_value": {"total": len(content), "description": old_description},
-            "value": len(content),
+            'start_value': {'total': len(content), 'description': old_description},
+            'value': len(content),
         },
         {
-            "start_value": {
-                "total": len(content),
+            'start_value': {
+                'total': len(content),
                 # Here there should be the new description
-                "description": new_description,
+                'description': new_description,
             },
-            "value": len(content),
+            'value': len(content),
         },
     ]
 
 
 @pytest.mark.parametrize(
-    "compression_algorithm,compressed_expected",
+    'compression_algorithm,compressed_expected',
     [
-        ["zlib+1", b"x\x013426153\xb7\xb040Df\x01\xf9\x00G\xb2\x05R"],
-        ["zlib+9", b"x\xda3426153\xb7\xb040Df\x01I\x00G\xb2\x05R"],
+        ['zlib+1', b'x\x013426153\xb7\xb040Df\x01\xf9\x00G\xb2\x05R'],
+        ['zlib+9', b'x\xda3426153\xb7\xb040Df\x01I\x00G\xb2\x05R'],
     ],
 )
 def test_compressers(compression_algorithm, compressed_expected):
     """Check that the data is compressed as expected."""
-    uncompressed = b"12345678901234567890123890"
+    uncompressed = b'12345678901234567890123890'
     compresser = utils.get_compressobj_instance(compression_algorithm)
     compressed = compresser.compress(uncompressed)
     compressed += compresser.flush()
@@ -1685,12 +1672,12 @@ def test_compressers(compression_algorithm, compressed_expected):
 def test_unknown_compressers():
     """Check that unknown or invalid compressers give a ValueError."""
     invalid_methods = [
-        "gzip",  # unknown
-        "zlib",  # no variant
-        "zlib+a",
-        "zlib+-1",
-        "zlib+10",
-        "unknown-method",  # Invalid variant
+        'gzip',  # unknown
+        'zlib',  # no variant
+        'zlib+a',
+        'zlib+-1',
+        'zlib+10',
+        'unknown-method',  # Invalid variant
     ]
     for invalid in invalid_methods:
         with pytest.raises(ValueError):
@@ -1699,8 +1686,8 @@ def test_unknown_compressers():
             utils.get_stream_decompresser(invalid)
 
 
-@pytest.mark.parametrize("source_compressed", [True, False])
-@pytest.mark.parametrize("compress_mode", list(utils.CompressMode))
+@pytest.mark.parametrize('source_compressed', [True, False])
+@pytest.mark.parametrize('compress_mode', list(utils.CompressMode))
 def test_should_compress(compress_mode, source_compressed):
     """Check if the should_compress method behaves as we expect on typical files.
 
@@ -1708,17 +1695,17 @@ def test_should_compress(compress_mode, source_compressed):
     """
     # Write 10*1_000_000 = 10 million bytes, larger than a chunk
     # this should be quite compressible even with the heuristics
-    content_compr = b"0123456789" * 1_000_000
+    content_compr = b'0123456789' * 1_000_000
     # This instead is 10 million random bytes, probably uncompressible
     content_uncompr = os.urandom(10_000_000)
 
     if source_compressed:
-        compresser = utils.get_compressobj_instance("zlib+1")
+        compresser = utils.get_compressobj_instance('zlib+1')
         compressed_compr = compresser.compress(content_compr)
         compressed_compr += compresser.flush()
         stream_compr = io.BytesIO(compressed_compr)
 
-        compresser = utils.get_compressobj_instance("zlib+1")
+        compresser = utils.get_compressobj_instance('zlib+1')
         compressed_uncompr = compresser.compress(content_uncompr)
         compressed_uncompr += compresser.flush()
         stream_uncompr = io.BytesIO(compressed_uncompr)
@@ -1763,11 +1750,11 @@ def test_should_compress(compress_mode, source_compressed):
 
 def test_should_compress_invalid_mode():
     """Check that an invalid compress_mode will raise."""
-    content = b"0123456789"
+    content = b'0123456789'
     with pytest.raises(NotImplementedError):
         utils.should_compress(
             io.BytesIO(content),
-            compress_mode="UNKNOWN_MODE",
+            compress_mode='UNKNOWN_MODE',
             source_compressed=False,
             source_length=len(content),
             source_size=len(content),
@@ -1776,7 +1763,7 @@ def test_should_compress_invalid_mode():
 
 def test_should_compress_empty_stream():
     """Check that it does not recommend to compress an empty stream."""
-    content = b""
+    content = b''
     assert not utils.should_compress(
         io.BytesIO(content),
         compress_mode=utils.CompressMode.AUTO,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,14 +54,10 @@ def test_lazy_opener_read():
             # The position should had moved by the right amount
             assert lazy.tell() == len(read_content)
 
-            assert (
-                len(current_process.open_files()) == start_open_files + 1
-            ), 'The count of open files is wrong!'
+            assert len(current_process.open_files()) == start_open_files + 1, 'The count of open files is wrong!'
             assert read_content == content, 'Unexpected content read from file'
 
-        assert (
-            len(current_process.open_files()) == start_open_files
-        ), 'The LazyOpener did not close the file on exit!'
+        assert len(current_process.open_files()) == start_open_files, 'The LazyOpener did not close the file on exit!'
 
         with pytest.raises(ValueError):
             # Should raise again after closing
@@ -151,11 +147,7 @@ def test_object_writer(temp_dir, loose_prefix_len):
     # that the prefix length is the expected one,
     # and that the content is correct
     if loose_prefix_len:
-        loose_filename = (
-            loose_folder
-            / obj_hashkey[:loose_prefix_len]
-            / obj_hashkey[loose_prefix_len:]
-        )
+        loose_filename = loose_folder / obj_hashkey[:loose_prefix_len] / obj_hashkey[loose_prefix_len:]
     else:
         loose_filename = loose_folder / obj_hashkey
     with open(loose_filename, 'rb') as fhandle:
@@ -195,9 +187,7 @@ def test_object_writer_duplicates_function(temp_dir):  # pylint: disable=invalid
     )
     # The duplicates folder should be empty at the beginning
     duplicates_files = os.listdir(duplicates_folder)
-    assert (
-        len(duplicates_files) == 1
-    ), f'There is more than one file in the duplicates! {duplicates_files}'
+    assert len(duplicates_files) == 1, f'There is more than one file in the duplicates! {duplicates_files}'
     duplicates_file = duplicates_files[0]
     # The duplicate should start with the hashkey followed by a dot
     assert duplicates_file.startswith(f'{hashkey}.')
@@ -320,9 +310,7 @@ def test_object_writer_not_twice(temp_dir):
         fhandle.write(content)
 
     obj_hashkey = object_writer.get_hashkey()
-    loose_filename = (
-        loose_folder / obj_hashkey[:loose_prefix_len] / obj_hashkey[loose_prefix_len:]
-    )
+    loose_filename = loose_folder / obj_hashkey[:loose_prefix_len] / obj_hashkey[loose_prefix_len:]
     with open(loose_filename, 'rb') as fhandle:
         # I have written the content twice
         assert fhandle.read() == content + content
@@ -655,9 +643,7 @@ def test_object_writer_existing_corrupted_reappears(  # pylint: disable=invalid-
         # If I trust existing files, the content shouldn't have been touched
         # (and the logic for reappears_corrupted is not really triggered)
         assert object_content == corrupted_content
-    elif (
-        os.name == 'nt' and not trust_existing and reappears_corrupted and dest_is_open
-    ):
+    elif os.name == 'nt' and not trust_existing and reappears_corrupted and dest_is_open:
         # Only in this extreme case (don't trust existing, the file reappears, it is
         # corrupted, and I couldn't overwrite the dest (loose file) because it was open,
         # then I'm left with the old content)
@@ -928,9 +914,7 @@ def test_packed_object_reader():
 
     # Offset beyond the file limit
     with open(tempfhandle.name, 'rb') as fhandle:
-        packed_reader = utils.PackedObjectReader(
-            fhandle, offset=len(bytestream) + 10, length=length
-        )
+        packed_reader = utils.PackedObjectReader(fhandle, offset=len(bytestream) + 10, length=length)
         assert packed_reader.read() == b''
 
     # Offset before the file limit, but longer length
@@ -977,10 +961,7 @@ def test_packed_object_reader_seek(tmp_path):
         for start in range(last_byte + 1):
             packed_reader.seek(start)
             assert packed_reader.tell() == start
-            assert (
-                packed_reader.read(last_byte - start)
-                == expected_bytestream[start:last_byte]
-            )
+            assert packed_reader.read(last_byte - start) == expected_bytestream[start:last_byte]
             assert packed_reader.tell() == last_byte
 
         # Reset the stream
@@ -1033,9 +1014,7 @@ def test_packed_object_reader_context_man(tmp_path):
         handle.write(bytestream)
 
     with open(str(tmp_path / 'pack'), 'rb') as fhandle:
-        with utils.PackedObjectReader(
-            fhandle, offset=0, length=len(bytestream)
-        ) as packed_reader:
+        with utils.PackedObjectReader(fhandle, offset=0, length=len(bytestream)) as packed_reader:
             assert packed_reader.read() == bytestream
 
 
@@ -1047,9 +1026,7 @@ def test_packed_object_reader_add(temp_container, open_streams):
         fhandle.write(content)
         fhandle.seek(0)
         wrapped = utils.PackedObjectReader(fhandle, 0, len(content))
-        hashkey = temp_container.add_streamed_object_to_pack(
-            wrapped, open_streams=open_streams
-        )
+        hashkey = temp_container.add_streamed_object_to_pack(wrapped, open_streams=open_streams)
     assert temp_container.get_object_content(hashkey) == content
 
 
@@ -1098,9 +1075,7 @@ def test_stream_decompresser(compression_algorithm):
         # Read in one chunk
         tmp = decompresser.read(size=0)
         assert not tmp
-        assert (
-            original == decompresser.read()
-        ), 'Uncompressed data is wrong (single read)'
+        assert original == decompresser.read(), 'Uncompressed data is wrong (single read)'
 
     compressed_streams = []
     for data in original_data:
@@ -1540,9 +1515,7 @@ def test_callback_stream_wrapper(callback_instance, with_total_length):
                 description=description,
             )
         else:
-            wrapped = utils.CallbackStreamWrapper(
-                fhandle, callback=callback_instance.callback, description=description
-            )
+            wrapped = utils.CallbackStreamWrapper(fhandle, callback=callback_instance.callback, description=description)
 
         assert wrapped.mode == 'rb+'
         assert wrapped.seekable()
@@ -1596,9 +1569,7 @@ def test_callback_stream_wrapper_add(temp_container, open_streams):
         fhandle.write(content)
         fhandle.seek(0)
         wrapped = utils.CallbackStreamWrapper(fhandle, None)
-        hashkey = temp_container.add_streamed_object_to_pack(
-            wrapped, open_streams=open_streams
-        )
+        hashkey = temp_container.add_streamed_object_to_pack(wrapped, open_streams=open_streams)
     assert temp_container.get_object_content(hashkey) == content
 
 
@@ -1625,9 +1596,7 @@ def test_rename_callback(callback_instance):
     # Now call with the modified one
     wrapped = utils.CallbackStreamWrapper(
         io.BytesIO(content),
-        callback=utils.rename_callback(
-            callback_instance.callback, new_description=new_description
-        ),
+        callback=utils.rename_callback(callback_instance.callback, new_description=new_description),
         total_length=len(content),
         description=old_description,
     )


### PR DESCRIPTION
pylint has some hardcoded requirements that were out of sync with `requirements.lock` and now with the `uv.lock`. Since this causes some errors when introducing support for >py3.11 I decided to switch to ruff since it does not require any dependencies. For type checking we still have mypyp so I don't think we are missing any coverage.

The settings are copied from `aiida-core`. In addition to the lint ignores in `aiida-core` I added these ones to not fix the code now.
```
  'N802', # Function name should be lowercase
  'N806', # Variable in functions should be always loweercase
  'N818', # Exception should be named with an Error suffix
  'E731', # Do not assign a lambda expression, use a def
  'RUF015', # Use next(iter(...))) for iteration over single element
  'PLC0206', # Extracting value from dictionary without calling `.items()`
  'PLW0602', # Using global without assignment
```

I separated it into two commits to make it clearer what has been changed and what are the consequences running pre-commit.

